### PR TITLE
release: @flex-development/tutils@5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [tutils@5.0.0](https://github.com/flex-development/tutils/compare/tutils@5.0.0-alpha.1...tutils@5.0.0) (2022-08-17)
+
+
+### :sparkles: Features
+
+* **types:** `ContinuousValue` ([2c95cd1](https://github.com/flex-development/tutils/commit/2c95cd11efdc9446e6a77d4030d9ceb15c82b090))
+* **types:** `NumberLike` ([a7af5d6](https://github.com/flex-development/tutils/commit/a7af5d6b7195c545b0e03890302b54f8590b2927))
+* **types:** `StringLike` ([c01856e](https://github.com/flex-development/tutils/commit/c01856eb036acf762487cc9ccf5de2f9539b10a1))
+
+
+### :house_with_garden: Housekeeping
+
+* **release:** fix release date for `tutils@5.0.0-dev.2` ([2b8e28d](https://github.com/flex-development/tutils/commit/2b8e28dff1797c095af879330cc6776d8880cb72))
+
 ## [tutils@5.0.0-alpha.1](https://github.com/flex-development/tutils/compare/tutils@5.0.0-dev.2...tutils@5.0.0-alpha.1) (2022-08-16)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flex-development/tutils",
   "description": "TypeScript utilities",
-  "version": "5.0.0-alpha.1",
+  "version": "5.0.0",
   "keywords": [
     "enums",
     "interfaces",


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

- bumped version to `5.0.0`
- added `CHANGELOG` entry for `5.0.0`

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

### `yarn test:cov`

```zsh
 RUN  v0.22.0
      Coverage enabled with c8

 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return false given ["cd"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return false given ["PROD"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["ci"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["development"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["staging"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["production"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["test"]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return false given [[]]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return false given [{}]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return false given [13]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return true given [true]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return true given ["true"]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return true given [false]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return true given ["false"]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given [[]]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given [{}]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given [13]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given [false]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given ["hello world"]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return true given [""]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return true given ["   "]
 ✓ src/guards/__tests__/is-empty-value.functional.spec.ts > functional:guards/isEmptyValue > should call isEmptyString 1 time and isNIL 0 times given [""]
 ✓ src/guards/__tests__/is-empty-value.functional.spec.ts > functional:guards/isEmptyValue > should call isEmptyString 1 time and isNIL 0 times given ["   "]
 ✓ src/guards/__tests__/is-empty-value.functional.spec.ts > functional:guards/isEmptyValue > should call isEmptyString 1 time and isNIL 1 time given [null]
 ✓ src/guards/__tests__/is-empty-value.functional.spec.ts > functional:guards/isEmptyValue > should call isEmptyString 1 time and isNIL 1 time given [undefined]
 ✓ src/guards/__tests__/is-jwt-type.spec.ts > unit:guards/isJwtType > should return false given ["EMAIL"]
 ✓ src/guards/__tests__/is-jwt-type.spec.ts > unit:guards/isJwtType > should return true given ["ACCESS"]
 ✓ src/guards/__tests__/is-jwt-type.spec.ts > unit:guards/isJwtType > should return true given ["REFRESH"]
 ✓ src/guards/__tests__/is-jwt-type.spec.ts > unit:guards/isJwtType > should return true given ["VERIFICATION"]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [[]]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [{}]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [13]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [true]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [false]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given ["string"]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return true given [null]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return true given [undefined]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return false given ["ci"]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return false given ["DEV"]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return true given ["development"]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return true given ["production"]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return true given ["test"]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return false given [[]]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return false given [{}]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return false given [true]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return false given [false]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return true given [13]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return true given ["hello world"]
 ✓ src/guards/__tests__/is-unix-timestamp.spec.ts > unit:guards/isUnixTimestamp > should return false given [null]
 ✓ src/guards/__tests__/is-unix-timestamp.spec.ts > unit:guards/isUnixTimestamp > should return true given [1660784662650]

Test Files  9 passed (9)
     Tests  50 passed (50)
  Start at  21:04:16
  Duration  5.86s (setup 1.58s, collect 113ms, tests 34ms)

 % Coverage report from c8
-----------------------|---------|----------|---------|---------|-------------------
File                   | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------|---------|----------|---------|---------|-------------------
All files              |   50.62 |    68.75 |   56.25 |   50.62 |                   
 enums                 |    23.8 |    33.33 |       0 |    23.8 |                   
  app-env.ts           |     100 |      100 |     100 |     100 |                   
  bson-type-alias.ts   |       0 |        0 |       0 |       0 | 1-22              
  bson-type-code.ts    |       0 |        0 |       0 |       0 | 1-22              
  compare-result.ts    |       0 |        0 |       0 |       0 | 1-21              
  http-status.ts       |       0 |        0 |       0 |       0 | 1-77              
  jwt-type.ts          |     100 |      100 |     100 |     100 |                   
  node-env.ts          |     100 |      100 |     100 |     100 |                   
  project-rule.ts      |       0 |        0 |       0 |       0 | 1-16              
  sort-order.ts        |       0 |        0 |       0 |       0 | 1-18              
 guards                |   87.95 |     82.6 |      90 |   87.95 |                   
  is-app-env.ts        |     100 |       50 |     100 |     100 | 15                
  is-booleanish.ts     |     100 |      100 |     100 |     100 |                   
  is-empty-string.ts   |     100 |      100 |     100 |     100 |                   
  is-empty-value.ts    |     100 |      100 |     100 |     100 |                   
  is-jwt-type.ts       |     100 |       50 |     100 |     100 | 15                
  is-nil.ts            |     100 |      100 |     100 |     100 |                   
  is-node-env.ts       |     100 |       50 |     100 |     100 | 15                
  is-number-string.ts  |     100 |      100 |     100 |     100 |                   
  is-unix-timestamp.ts |       0 |        0 |       0 |       0 | 1-20              
-----------------------|---------|----------|---------|---------|-------------------
```

### `yarn build`

```zsh
ℹ Building @flex-development/tutils                                                        21:06:25
✔ Build succeeded for tutils                                                               21:06:31
  dist (total size: 46.5 kB)                                                               21:06:31
  └─ dist/enums/app-env.d.ts (283 B)
  └─ dist/guards/index.d.ts (530 B)
  └─ dist/types/any.d.ts (164 B)
  └─ dist/index.d.ts (131 B)
  └─ dist/enums/app-env.mjs (254 B)
  └─ dist/index.mjs (106 B)
  └─ dist/enums/bson-type-alias.d.ts (432 B)
  └─ dist/enums/bson-type-alias.mjs (359 B)
  └─ dist/enums/bson-type-code.d.ts (390 B)
  └─ dist/enums/bson-type-code.mjs (466 B)
  └─ dist/enums/http-status.d.ts (1.89 kB)
  └─ dist/enums/compare-result.d.ts (445 B)
  └─ dist/enums/compare-result.mjs (333 B)
  └─ dist/enums/index.d.ts (554 B)
  └─ dist/enums/http-status.mjs (4.55 kB)
  └─ dist/enums/jwt-type.d.ts (291 B)
  └─ dist/enums/node-env.d.ts (244 B)
  └─ dist/enums/node-env.mjs (208 B)
  └─ dist/enums/project-rule.d.ts (253 B)
  └─ dist/enums/jwt-type.mjs (222 B)
  └─ dist/enums/project-rule.mjs (231 B)
  └─ dist/enums/sort-order.d.ts (333 B)
  └─ dist/enums/sort-order.mjs (236 B)
  └─ dist/guards/is-app-env.d.ts (316 B)
  └─ dist/guards/is-booleanish.d.ts (351 B)
  └─ dist/guards/is-booleanish.mjs (144 B)
  └─ dist/guards/is-empty-string.mjs (134 B)
  └─ dist/guards/is-jwt-type.mjs (154 B)
  └─ dist/guards/is-jwt-type.d.ts (314 B)
  └─ dist/guards/is-nil.d.ts (297 B)
  └─ dist/guards/is-nil.mjs (97 B)
  └─ dist/guards/is-node-env.d.ts (343 B)
  └─ dist/guards/is-node-env.mjs (177 B)
  └─ dist/guards/is-number-string.d.ts (352 B)
  └─ dist/guards/is-empty-string.d.ts (333 B)
  └─ dist/guards/is-number-string.mjs (135 B)
  └─ dist/types/any.mjs (11 B)
  └─ dist/guards/is-unix-timestamp.d.ts (417 B)
  └─ dist/guards/is-unix-timestamp.mjs (153 B)
  └─ dist/types/booleanish.d.ts (244 B)
  └─ dist/types/booleanish.mjs (11 B)
  └─ dist/types/built-in.d.ts (251 B)
  └─ dist/types/class-constructor.d.ts (488 B)
  └─ dist/guards/is-empty-value.d.ts (358 B)
  └─ dist/types/comparison-operator.mjs (11 B)
  └─ dist/types/continuous-value.d.ts (283 B)
  └─ dist/types/continuous-value.mjs (11 B)
  └─ dist/guards/is-empty-value.mjs (198 B)
  └─ dist/types/deep-omit.d.ts (2.51 kB)
  └─ dist/types/deep-omit.mjs (11 B)
  └─ dist/types/deep-partial.d.ts (1.13 kB)
  └─ dist/types/deep-partial.mjs (11 B)
  └─ dist/types/class-constructor.mjs (11 B)
  └─ dist/types/deep-pick.d.ts (760 B)
  └─ dist/types/deep-required.d.ts (1.06 kB)
  └─ dist/types/deep-required.mjs (11 B)
  └─ dist/types/deep-pick.mjs (11 B)
  └─ dist/types/document-partial.d.ts (797 B)
  └─ dist/types/duid.d.ts (195 B)
  └─ dist/types/document-partial.mjs (11 B)
  └─ dist/types/empty-string.d.ts (201 B)
  └─ dist/types/empty-string.mjs (11 B)
  └─ dist/types/empty-value.d.ts (312 B)
  └─ dist/types/empty-value.mjs (11 B)
  └─ dist/types/fixme.mjs (11 B)
  └─ dist/types/index-signature.d.ts (308 B)
  └─ dist/types/index-signature.mjs (11 B)
  └─ dist/types/fixme.d.ts (210 B)
  └─ dist/types/index.d.ts (3.42 kB)
  └─ dist/types/index.mjs
  └─ dist/types/intersection.d.ts (404 B)
  └─ dist/types/is-tuple.d.ts (515 B)
  └─ dist/types/intersection.mjs (11 B)
  └─ dist/types/is-tuple.mjs (11 B)
  └─ dist/types/join.d.ts (506 B)
  └─ dist/types/join.mjs (11 B)
  └─ dist/types/json-array.d.ts (316 B)
  └─ dist/types/json-array.mjs (11 B)
  └─ dist/types/json-object.d.ts (760 B)
  └─ dist/types/built-in.mjs (11 B)
  └─ dist/types/json-primitive.mjs (11 B)
  └─ dist/types/json-primitive.d.ts (370 B)
  └─ dist/types/json-value.d.ts (405 B)
  └─ dist/types/json-value.mjs (11 B)
  └─ dist/types/keys-required.d.ts (444 B)
  └─ dist/types/keys-required.mjs (11 B)
  └─ dist/types/keys-optional.d.ts (467 B)
  └─ dist/types/keys-optional.mjs (11 B)
  └─ dist/types/nil.d.ts (197 B)
  └─ dist/types/nullable.mjs (11 B)
  └─ dist/types/nullish-boolean.d.ts (245 B)
  └─ dist/types/nullish-boolean.mjs (11 B)
  └─ dist/types/nullish-number.d.ts (239 B)
  └─ dist/types/nullish-number.mjs (11 B)
  └─ dist/types/nullish-string.d.ts (239 B)
  └─ dist/types/nullish-string.mjs (11 B)
  └─ dist/types/number-like.d.ts (263 B)
  └─ dist/types/number-like.mjs (11 B)
  └─ dist/types/nullable.d.ts (256 B)
  └─ dist/types/number-string.d.ts (225 B)
  └─ dist/types/numeric.mjs (11 B)
  └─ dist/types/numeric.d.ts (196 B)
  └─ dist/types/number-string.mjs (11 B)
  └─ dist/types/object-empty.d.ts (221 B)
  └─ dist/types/comparison-operator.d.ts (272 B)
  └─ dist/types/object-plain.d.ts (304 B)
  └─ dist/types/object-empty.mjs (11 B)
  └─ dist/types/object-plain.mjs (11 B)
  └─ dist/types/object-unknown.mjs (11 B)
  └─ dist/types/object-unknown.d.ts (297 B)
  └─ dist/types/one-or-many.d.ts (253 B)
  └─ dist/types/one-or-many.mjs (11 B)
  └─ dist/types/omit-by-type.d.ts (451 B)
  └─ dist/types/duid.mjs (11 B)
  └─ dist/types/or-deep-partial.mjs (11 B)
  └─ dist/types/or-never.d.ts (325 B)
  └─ dist/types/or-never.mjs (11 B)
  └─ dist/types/or-nil.d.ts (257 B)
  └─ dist/types/or-nil.mjs (11 B)
  └─ dist/types/nil.mjs (11 B)
  └─ dist/types/or-null.d.ts (233 B)
  └─ dist/types/or-null.mjs (11 B)
  └─ dist/types/omit-by-type.mjs (11 B)
  └─ dist/types/or-partial.d.ts (300 B)
  └─ dist/types/or-partial.mjs (11 B)
  └─ dist/types/or-promise.d.ts (260 B)
  └─ dist/types/or-undefined.mjs (11 B)
  └─ dist/types/overwrite.d.ts (461 B)
  └─ dist/types/or-undefined.d.ts (263 B)
  └─ dist/types/path-n.mjs (11 B)
  └─ dist/types/path-nt.d.ts (476 B)
  └─ dist/types/path-nt.mjs (11 B)
  └─ dist/types/overwrite.mjs (11 B)
  └─ dist/types/json-object.mjs (11 B)
  └─ dist/types/path.d.ts (540 B)
  └─ dist/types/or-promise.mjs (11 B)
  └─ dist/types/path.mjs (11 B)
  └─ dist/types/pick-by-type.mjs (11 B)
  └─ dist/types/pick-by-type.d.ts (450 B)
  └─ dist/types/primitive.d.ts (359 B)
  └─ dist/types/split.d.ts (431 B)
  └─ dist/types/regex-string.mjs (11 B)
  └─ dist/types/regex-string.d.ts (234 B)
  └─ dist/types/split.mjs (11 B)
  └─ dist/types/path-n.d.ts (691 B)
  └─ dist/types/string-like.mjs (11 B)
  └─ dist/types/timestamp-unix.d.ts (279 B)
  └─ dist/types/timestamp-unix.mjs (11 B)
  └─ dist/types/or-deep-partial.d.ts (367 B)
  └─ dist/types/path-value.d.ts (694 B)
  └─ dist/types/string-like.d.ts (229 B)
  └─ dist/types/uid.d.ts (231 B)
  └─ dist/types/path-value.mjs (11 B)
  └─ dist/types/union.d.ts (464 B)
  └─ dist/types/primitive.mjs (11 B)
  └─ dist/guards/index.mjs (494 B)
  └─ dist/guards/is-app-env.mjs (149 B)
  └─ dist/types/uid.mjs (11 B)
  └─ dist/enums/index.mjs (529 B)
  └─ dist/types/union.mjs (11 B)
  dist (total size: 57.2 kB)                                                               21:06:31
  └─ dist/index.d.cts (131 B)
  └─ dist/index.cjs (1.09 kB)
  └─ dist/enums/bson-type-alias.d.cts (432 B)
  └─ dist/enums/bson-type-alias.cjs (489 B)
  └─ dist/enums/app-env.d.cts (283 B)
  └─ dist/enums/http-status.d.cts (1.89 kB)
  └─ dist/enums/compare-result.d.cts (445 B)
  └─ dist/enums/index.cjs (1.98 kB)
  └─ dist/enums/bson-type-code.cjs (596 B)
  └─ dist/enums/app-env.cjs (384 B)
  └─ dist/enums/jwt-type.cjs (352 B)
  └─ dist/enums/http-status.cjs (4.68 kB)
  └─ dist/enums/node-env.d.cts (244 B)
  └─ dist/enums/project-rule.d.cts (253 B)
  └─ dist/enums/project-rule.cjs (361 B)
  └─ dist/enums/node-env.cjs (338 B)
  └─ dist/enums/index.d.cts (554 B)
  └─ dist/guards/index.d.cts (530 B)
  └─ dist/enums/sort-order.cjs (366 B)
  └─ dist/enums/sort-order.d.cts (333 B)
  └─ dist/guards/is-app-env.cjs (415 B)
  └─ dist/guards/is-booleanish.cjs (275 B)
  └─ dist/enums/compare-result.cjs (463 B)
  └─ dist/guards/is-empty-string.d.cts (333 B)
  └─ dist/guards/is-booleanish.d.cts (351 B)
  └─ dist/guards/is-empty-string.cjs (265 B)
  └─ dist/guards/is-empty-value.d.cts (358 B)
  └─ dist/enums/bson-type-code.d.cts (390 B)
  └─ dist/guards/is-app-env.d.cts (316 B)
  └─ dist/guards/is-empty-value.cjs (512 B)
  └─ dist/guards/is-node-env.d.cts (343 B)
  └─ dist/guards/is-nil.d.cts (297 B)
  └─ dist/guards/is-number-string.d.cts (352 B)
  └─ dist/guards/is-jwt-type.d.cts (314 B)
  └─ dist/guards/is-unix-timestamp.d.cts (417 B)
  └─ dist/enums/jwt-type.d.cts (291 B)
  └─ dist/guards/index.cjs (1.82 kB)
  └─ dist/guards/is-unix-timestamp.cjs (284 B)
  └─ dist/types/booleanish.d.cts (244 B)
  └─ dist/guards/is-jwt-type.cjs (420 B)
  └─ dist/guards/is-nil.cjs (228 B)
  └─ dist/types/built-in.d.cts (251 B)
  └─ dist/types/booleanish.cjs (79 B)
  └─ dist/types/built-in.cjs (79 B)
  └─ dist/types/comparison-operator.d.cts (272 B)
  └─ dist/types/comparison-operator.cjs (79 B)
  └─ dist/guards/is-node-env.cjs (445 B)
  └─ dist/types/any.cjs (79 B)
  └─ dist/types/continuous-value.cjs (79 B)
  └─ dist/types/class-constructor.cjs (79 B)
  └─ dist/types/deep-partial.d.cts (1.13 kB)
  └─ dist/types/deep-omit.d.cts (2.51 kB)
  └─ dist/types/deep-omit.cjs (79 B)
  └─ dist/types/deep-partial.cjs (79 B)
  └─ dist/guards/is-number-string.cjs (266 B)
  └─ dist/types/continuous-value.d.cts (283 B)
  └─ dist/types/document-partial.cjs (79 B)
  └─ dist/types/deep-required.d.cts (1.06 kB)
  └─ dist/types/duid.d.cts (195 B)
  └─ dist/types/duid.cjs (79 B)
  └─ dist/types/deep-pick.cjs (79 B)
  └─ dist/types/empty-value.d.cts (312 B)
  └─ dist/types/any.d.cts (164 B)
  └─ dist/types/fixme.cjs (79 B)
  └─ dist/types/fixme.d.cts (210 B)
  └─ dist/types/empty-value.cjs (79 B)
  └─ dist/types/index-signature.d.cts (308 B)
  └─ dist/types/empty-string.cjs (79 B)
  └─ dist/types/empty-string.d.cts (201 B)
  └─ dist/types/index.cjs (13 B)
  └─ dist/types/class-constructor.d.cts (488 B)
  └─ dist/types/deep-required.cjs (79 B)
  └─ dist/types/index-signature.cjs (79 B)
  └─ dist/types/deep-pick.d.cts (760 B)
  └─ dist/types/document-partial.d.cts (797 B)
  └─ dist/types/is-tuple.cjs (79 B)
  └─ dist/types/json-array.d.cts (316 B)
  └─ dist/types/intersection.cjs (79 B)
  └─ dist/types/is-tuple.d.cts (515 B)
  └─ dist/types/index.d.cts (3.42 kB)
  └─ dist/types/json-array.cjs (79 B)
  └─ dist/types/json-object.d.cts (760 B)
  └─ dist/types/json-value.cjs (79 B)
  └─ dist/types/json-value.d.cts (405 B)
  └─ dist/types/json-object.cjs (79 B)
  └─ dist/types/json-primitive.d.cts (370 B)
  └─ dist/types/keys-optional.cjs (79 B)
  └─ dist/types/keys-required.d.cts (444 B)
  └─ dist/types/intersection.d.cts (404 B)
  └─ dist/types/keys-required.cjs (79 B)
  └─ dist/types/keys-optional.d.cts (467 B)
  └─ dist/types/json-primitive.cjs (79 B)
  └─ dist/types/join.d.cts (506 B)
  └─ dist/types/nullable.cjs (79 B)
  └─ dist/types/join.cjs (79 B)
  └─ dist/types/nil.d.cts (197 B)
  └─ dist/types/nullish-boolean.cjs (79 B)
  └─ dist/types/nullish-string.d.cts (239 B)
  └─ dist/types/nil.cjs (79 B)
  └─ dist/types/nullable.d.cts (256 B)
  └─ dist/types/nullish-number.cjs (79 B)
  └─ dist/types/nullish-boolean.d.cts (245 B)
  └─ dist/types/number-string.cjs (79 B)
  └─ dist/types/nullish-number.d.cts (239 B)
  └─ dist/types/number-like.d.cts (263 B)
  └─ dist/types/object-plain.cjs (79 B)
  └─ dist/types/object-empty.d.cts (221 B)
  └─ dist/types/object-unknown.d.cts (297 B)
  └─ dist/types/object-empty.cjs (79 B)
  └─ dist/types/object-plain.d.cts (304 B)
  └─ dist/types/number-like.cjs (79 B)
  └─ dist/types/numeric.cjs (79 B)
  └─ dist/types/nullish-string.cjs (79 B)
  └─ dist/types/numeric.d.cts (196 B)
  └─ dist/types/object-unknown.cjs (79 B)
  └─ dist/types/omit-by-type.d.cts (451 B)
  └─ dist/types/or-deep-partial.d.cts (367 B)
  └─ dist/types/one-or-many.d.cts (253 B)
  └─ dist/types/or-never.cjs (79 B)
  └─ dist/types/omit-by-type.cjs (79 B)
  └─ dist/types/or-deep-partial.cjs (79 B)
  └─ dist/types/one-or-many.cjs (79 B)
  └─ dist/types/or-nil.cjs (79 B)
  └─ dist/types/or-nil.d.cts (257 B)
  └─ dist/types/or-never.d.cts (325 B)
  └─ dist/types/or-null.cjs (79 B)
  └─ dist/types/or-null.d.cts (233 B)
  └─ dist/types/or-partial.cjs (79 B)
  └─ dist/types/or-promise.d.cts (260 B)
  └─ dist/types/or-partial.d.cts (300 B)
  └─ dist/types/number-string.d.cts (225 B)
  └─ dist/types/or-promise.cjs (79 B)
  └─ dist/types/path-nt.d.cts (476 B)
  └─ dist/types/path-value.d.cts (694 B)
  └─ dist/types/path-value.cjs (79 B)
  └─ dist/types/path-n.d.cts (691 B)
  └─ dist/types/or-undefined.d.cts (263 B)
  └─ dist/types/overwrite.cjs (79 B)
  └─ dist/types/pick-by-type.cjs (79 B)
  └─ dist/types/overwrite.d.cts (461 B)
  └─ dist/types/path.d.cts (540 B)
  └─ dist/types/primitive.cjs (79 B)
  └─ dist/types/regex-string.cjs (79 B)
  └─ dist/types/path-nt.cjs (79 B)
  └─ dist/types/split.cjs (79 B)
  └─ dist/types/split.d.cts (431 B)
  └─ dist/types/regex-string.d.cts (234 B)
  └─ dist/types/timestamp-unix.d.cts (279 B)
  └─ dist/types/path-n.cjs (79 B)
  └─ dist/types/string-like.cjs (79 B)
  └─ dist/types/or-undefined.cjs (79 B)
  └─ dist/types/path.cjs (79 B)
  └─ dist/types/uid.d.cts (231 B)
  └─ dist/types/string-like.d.cts (229 B)
  └─ dist/types/union.d.cts (464 B)
  └─ dist/types/uid.cjs (79 B)
  └─ dist/types/union.cjs (79 B)
  └─ dist/types/timestamp-unix.cjs (79 B)
  └─ dist/types/primitive.d.cts (359 B)
  └─ dist/types/pick-by-type.d.cts (450 B)
  dist (total size: 46.5 kB)                                                               21:06:31
  └─ dist/index.mjs (106 B)
  └─ dist/index.d.mts (131 B)
  └─ dist/enums/bson-type-alias.d.mts (432 B)
  └─ dist/enums/bson-type-alias.mjs (359 B)
  └─ dist/enums/bson-type-code.d.mts (390 B)
  └─ dist/enums/compare-result.d.mts (445 B)
  └─ dist/enums/compare-result.mjs (333 B)
  └─ dist/enums/http-status.mjs (4.55 kB)
  └─ dist/enums/index.d.mts (554 B)
  └─ dist/enums/jwt-type.d.mts (291 B)
  └─ dist/enums/index.mjs (529 B)
  └─ dist/enums/jwt-type.mjs (222 B)
  └─ dist/enums/project-rule.mjs (231 B)
  └─ dist/enums/node-env.d.mts (244 B)
  └─ dist/enums/node-env.mjs (208 B)
  └─ dist/enums/sort-order.mjs (236 B)
  └─ dist/enums/sort-order.d.mts (333 B)
  └─ dist/guards/index.d.mts (530 B)
  └─ dist/enums/http-status.d.mts (1.89 kB)
  └─ dist/guards/index.mjs (494 B)
  └─ dist/guards/is-app-env.d.mts (316 B)
  └─ dist/guards/is-booleanish.d.mts (351 B)
  └─ dist/guards/is-app-env.mjs (149 B)
  └─ dist/guards/is-booleanish.mjs (144 B)
  └─ dist/guards/is-empty-string.d.mts (333 B)
  └─ dist/guards/is-empty-value.d.mts (358 B)
  └─ dist/guards/is-empty-string.mjs (134 B)
  └─ dist/enums/project-rule.d.mts (253 B)
  └─ dist/guards/is-nil.d.mts (297 B)
  └─ dist/guards/is-empty-value.mjs (198 B)
  └─ dist/guards/is-node-env.mjs (177 B)
  └─ dist/guards/is-node-env.d.mts (343 B)
  └─ dist/guards/is-jwt-type.mjs (154 B)
  └─ dist/guards/is-number-string.d.mts (352 B)
  └─ dist/enums/bson-type-code.mjs (466 B)
  └─ dist/guards/is-unix-timestamp.d.mts (417 B)
  └─ dist/guards/is-nil.mjs (97 B)
  └─ dist/types/any.d.mts (164 B)
  └─ dist/guards/is-unix-timestamp.mjs (153 B)
  └─ dist/types/booleanish.d.mts (244 B)
  └─ dist/types/any.mjs (11 B)
  └─ dist/types/booleanish.mjs (11 B)
  └─ dist/types/built-in.d.mts (251 B)
  └─ dist/types/built-in.mjs (11 B)
  └─ dist/types/class-constructor.d.mts (488 B)
  └─ dist/types/comparison-operator.d.mts (272 B)
  └─ dist/types/comparison-operator.mjs (11 B)
  └─ dist/types/continuous-value.mjs (11 B)
  └─ dist/types/class-constructor.mjs (11 B)
  └─ dist/types/deep-partial.d.mts (1.13 kB)
  └─ dist/types/continuous-value.d.mts (283 B)
  └─ dist/types/deep-partial.mjs (11 B)
  └─ dist/types/deep-pick.d.mts (760 B)
  └─ dist/types/deep-pick.mjs (11 B)
  └─ dist/guards/is-jwt-type.d.mts (314 B)
  └─ dist/types/deep-required.d.mts (1.06 kB)
  └─ dist/types/deep-required.mjs (11 B)
  └─ dist/types/deep-omit.mjs (11 B)
  └─ dist/types/document-partial.mjs (11 B)
  └─ dist/guards/is-number-string.mjs (135 B)
  └─ dist/types/duid.mjs (11 B)
  └─ dist/types/empty-string.mjs (11 B)
  └─ dist/types/duid.d.mts (195 B)
  └─ dist/types/empty-value.d.mts (312 B)
  └─ dist/enums/app-env.mjs (254 B)
  └─ dist/types/deep-omit.d.mts (2.51 kB)
  └─ dist/enums/app-env.d.mts (283 B)
  └─ dist/types/index.mjs
  └─ dist/types/document-partial.d.mts (797 B)
  └─ dist/types/index-signature.mjs (11 B)
  └─ dist/types/index.d.mts (3.42 kB)
  └─ dist/types/empty-string.d.mts (201 B)
  └─ dist/types/intersection.d.mts (404 B)
  └─ dist/types/is-tuple.mjs (11 B)
  └─ dist/types/intersection.mjs (11 B)
  └─ dist/types/join.d.mts (506 B)
  └─ dist/types/fixme.mjs (11 B)
  └─ dist/types/json-array.d.mts (316 B)
  └─ dist/types/join.mjs (11 B)
  └─ dist/types/json-primitive.d.mts (370 B)
  └─ dist/types/json-value.mjs (11 B)
  └─ dist/types/json-array.mjs (11 B)
  └─ dist/types/keys-optional.d.mts (467 B)
  └─ dist/types/is-tuple.d.mts (515 B)
  └─ dist/types/keys-optional.mjs (11 B)
  └─ dist/types/json-object.mjs (11 B)
  └─ dist/types/index-signature.d.mts (308 B)
  └─ dist/types/keys-required.mjs (11 B)
  └─ dist/types/nil.d.mts (197 B)
  └─ dist/types/nullable.d.mts (256 B)
  └─ dist/types/nil.mjs (11 B)
  └─ dist/types/nullable.mjs (11 B)
  └─ dist/types/nullish-boolean.mjs (11 B)
  └─ dist/types/nullish-boolean.d.mts (245 B)
  └─ dist/types/fixme.d.mts (210 B)
  └─ dist/types/keys-required.d.mts (444 B)
  └─ dist/types/json-object.d.mts (760 B)
  └─ dist/types/number-like.d.mts (263 B)
  └─ dist/types/json-primitive.mjs (11 B)
  └─ dist/types/number-string.d.mts (225 B)
  └─ dist/types/nullish-number.mjs (11 B)
  └─ dist/types/number-string.mjs (11 B)
  └─ dist/types/nullish-string.d.mts (239 B)
  └─ dist/types/numeric.d.mts (196 B)
  └─ dist/types/json-value.d.mts (405 B)
  └─ dist/types/nullish-string.mjs (11 B)
  └─ dist/types/object-plain.d.mts (304 B)
  └─ dist/types/empty-value.mjs (11 B)
  └─ dist/types/object-unknown.mjs (11 B)
  └─ dist/types/object-unknown.d.mts (297 B)
  └─ dist/types/omit-by-type.d.mts (451 B)
  └─ dist/types/omit-by-type.mjs (11 B)
  └─ dist/types/nullish-number.d.mts (239 B)
  └─ dist/types/one-or-many.d.mts (253 B)
  └─ dist/types/or-never.d.mts (325 B)
  └─ dist/types/or-deep-partial.mjs (11 B)
  └─ dist/types/or-nil.d.mts (257 B)
  └─ dist/types/numeric.mjs (11 B)
  └─ dist/types/one-or-many.mjs (11 B)
  └─ dist/types/or-null.d.mts (233 B)
  └─ dist/types/number-like.mjs (11 B)
  └─ dist/types/or-partial.d.mts (300 B)
  └─ dist/types/or-partial.mjs (11 B)
  └─ dist/types/object-empty.d.mts (221 B)
  └─ dist/types/object-empty.mjs (11 B)
  └─ dist/types/or-promise.d.mts (260 B)
  └─ dist/types/or-promise.mjs (11 B)
  └─ dist/types/or-undefined.mjs (11 B)
  └─ dist/types/overwrite.mjs (11 B)
  └─ dist/types/overwrite.d.mts (461 B)
  └─ dist/types/object-plain.mjs (11 B)
  └─ dist/types/path-nt.d.mts (476 B)
  └─ dist/types/or-deep-partial.d.mts (367 B)
  └─ dist/types/path-n.mjs (11 B)
  └─ dist/types/or-null.mjs (11 B)
  └─ dist/types/or-never.mjs (11 B)
  └─ dist/types/pick-by-type.d.mts (450 B)
  └─ dist/types/path.mjs (11 B)
  └─ dist/types/or-undefined.d.mts (263 B)
  └─ dist/types/primitive.d.mts (359 B)
  └─ dist/types/primitive.mjs (11 B)
  └─ dist/types/regex-string.d.mts (234 B)
  └─ dist/types/regex-string.mjs (11 B)
  └─ dist/types/path-value.d.mts (694 B)
  └─ dist/types/path-nt.mjs (11 B)
  └─ dist/types/path-value.mjs (11 B)
  └─ dist/types/split.mjs (11 B)
  └─ dist/types/string-like.d.mts (229 B)
  └─ dist/types/string-like.mjs (11 B)
  └─ dist/types/timestamp-unix.mjs (11 B)
  └─ dist/types/path.d.mts (540 B)
  └─ dist/types/split.d.mts (431 B)
  └─ dist/types/uid.d.mts (231 B)
  └─ dist/types/pick-by-type.mjs (11 B)
  └─ dist/types/path-n.d.mts (691 B)
  └─ dist/types/union.d.mts (464 B)
  └─ dist/types/uid.mjs (11 B)
  └─ dist/types/union.mjs (11 B)
  └─ dist/types/or-nil.mjs (11 B)
  └─ dist/types/timestamp-unix.d.mts (279 B)
Σ Total dist size (byte size): 140 kB
                                                                                           21:06:31
```

## Additional context

<!-- Add any other information (docs, files, issue references, etc) about the pull request here. -->

N/A

## Linked issues

<!-- closes #[issue number], fixes #[issue number] -->

- resolves #29 
- releases #36 

## Submission checklist

- [x] [pr naming conventions][1]
- [x] project was run locally to verify that there are no errors
- [x] documentation added or updated

[1]: https://github.com/flex-development/tutils/blob/main/CONTRIBUTING.md#pull-request-titles
