### PR TITLE
release: tutils@5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,99 @@
+## [tutils@5.0.1](https://github.com/flex-development/tutils/compare/tutils@5.0.0...tutils@5.0.1) (2022-09-30)
+
+
+### :package: Build
+
+* require at least node.js 14 ([572ca73](https://github.com/flex-development/tutils/commit/572ca7302ae528c822964d1be44dad772273d8b1))
+* set `typesVersions` ([20cfa15](https://github.com/flex-development/tutils/commit/20cfa15b15f9b45374a63882030d0f01498bb155))
+* use `mkbuild` to build project ([94e3cc1](https://github.com/flex-development/tutils/commit/94e3cc154428e18b3d4da83aa2e729e26f51b52b))
+* **deps-dev:** bump @types/eslint from 8.4.5 to 8.4.6 ([#56](https://github.com/flex-development/tutils/issues/56)) ([0bd61c6](https://github.com/flex-development/tutils/commit/0bd61c64e8d90a2252879fd37cc0be82de5a79b3))
+* **deps-dev:** bump @typescript-eslint/eslint-plugin from 5.33.1 to 5.34.0 ([#64](https://github.com/flex-development/tutils/issues/64)) ([3f91307](https://github.com/flex-development/tutils/commit/3f913073edc2dcf4f484365a0345f1e48882e78d))
+* **deps-dev:** bump @typescript-eslint/eslint-plugin from 5.34.0 to 5.35.1 ([#67](https://github.com/flex-development/tutils/issues/67)) ([03cf64d](https://github.com/flex-development/tutils/commit/03cf64d8707ed9d793f770e8fc01d087e3309c7f))
+* **deps-dev:** bump @typescript-eslint/parser from 5.33.1 to 5.34.0 ([#65](https://github.com/flex-development/tutils/issues/65)) ([11cb8b9](https://github.com/flex-development/tutils/commit/11cb8b9efda8f211f8fbb6f54e54e0950cdf89b3))
+* **deps-dev:** bump @typescript-eslint/parser from 5.34.0 to 5.35.1 ([#66](https://github.com/flex-development/tutils/issues/66)) ([dfc4796](https://github.com/flex-development/tutils/commit/dfc479649ca926c30387367605aec2a6ba23470d))
+* **deps-dev:** bump @vitest/coverage-c8 from 0.22.0 to 0.22.1 ([#62](https://github.com/flex-development/tutils/issues/62)) ([3f2eb47](https://github.com/flex-development/tutils/commit/3f2eb473fa0e2efd9c62a8b6c2efd915b90d3fe0))
+* **deps-dev:** bump @vitest/ui from 0.22.0 to 0.22.1 ([#60](https://github.com/flex-development/tutils/issues/60)) ([91363f6](https://github.com/flex-development/tutils/commit/91363f6e88e2911953d2560cc02408c49eebdbc2))
+* **deps-dev:** bump cspell from 6.6.1 to 6.7.0 ([#58](https://github.com/flex-development/tutils/issues/58)) ([8bb6770](https://github.com/flex-development/tutils/commit/8bb67700a3fc2e1a3c0eb810fd0fd65d26b9a8d2))
+* **deps-dev:** bump cspell from 6.7.0 to 6.8.0 ([#63](https://github.com/flex-development/tutils/issues/63)) ([a500255](https://github.com/flex-development/tutils/commit/a5002552e279beafa57e29af753e58d6b298e352))
+* **deps-dev:** bump eslint-plugin-jsonc from 2.3.1 to 2.4.0 ([1e45ef3](https://github.com/flex-development/tutils/commit/1e45ef33bbb9d7c46411ab4fe9a412172525ddbe))
+* **deps-dev:** bump eslint-plugin-promise from 6.0.0 to 6.0.1 ([#69](https://github.com/flex-development/tutils/issues/69)) ([5ec7516](https://github.com/flex-development/tutils/commit/5ec751632a2bdc7d10b38b95a1530e07a9dc63d6))
+* **deps-dev:** bump eslint-plugin-react from 7.30.1 to 7.31.0 ([#68](https://github.com/flex-development/tutils/issues/68)) ([5bde4b7](https://github.com/flex-development/tutils/commit/5bde4b7c276dafc5285864a3401b7448bf5e0002))
+* **deps-dev:** bump pretty-format from 28.1.3 to 29.0.0 ([efc38f9](https://github.com/flex-development/tutils/commit/efc38f97116398686654087c6ccf0f2bd9bb45f6))
+* **deps-dev:** bump unbuild from 0.8.8 to 0.8.9 ([#61](https://github.com/flex-development/tutils/issues/61)) ([4add30f](https://github.com/flex-development/tutils/commit/4add30f6a2a449cee762c2049ca369363c7663d7))
+* **deps-dev:** bump vitest from 0.22.0 to 0.22.1 ([#59](https://github.com/flex-development/tutils/issues/59)) ([0de2679](https://github.com/flex-development/tutils/commit/0de267942eccd09b68ea72413c1ff555b188e045))
+* **exports:** remove extraneous conditional `types` exports ([13b7990](https://github.com/flex-development/tutils/commit/13b7990b9b5f1b45a630b248444fc96d7f13c1d3))
+* **pkg:** set type to `module` ([59fcf62](https://github.com/flex-development/tutils/commit/59fcf62c5e02c8b90e12388d3af919493f33710e))
+
+
+### :robot: Continuous Integration
+
+* let [@dependabot](https://github.com/dependabot) check for new versions at random times ([7e4b90e](https://github.com/flex-development/tutils/commit/7e4b90e0679ec201e62d55b464978d8009843a5b))
+* refactor [@dependabot](https://github.com/dependabot) workflow ([df65f3f](https://github.com/flex-development/tutils/commit/df65f3fa1152fcf728fca9fa3221d98293405d1a))
+* **deps:** bump flex-development/dist-tag-action from 1.0.0 to 1.1.0 ([#55](https://github.com/flex-development/tutils/issues/55)) ([678c3d0](https://github.com/flex-development/tutils/commit/678c3d048e7ca0fbc267d08702f93f734442e4fc))
+* **workflows:** `add-to-project` ([20ee547](https://github.com/flex-development/tutils/commit/20ee5479a6acf87bd44de40fe43b5a51d198255c))
+* **workflows:** `dependabot-auto-fix` ([70d519a](https://github.com/flex-development/tutils/commit/70d519afb5bd575282524da664ecad03f096c47f))
+* **workflows:** add debug step to ci workflow ([f2f1d17](https://github.com/flex-development/tutils/commit/f2f1d173d91541d494ee28829375f4c6a2bb7e02))
+* **workflows:** add gh pat for [@dependabot](https://github.com/dependabot) ([d1ccb27](https://github.com/flex-development/tutils/commit/d1ccb270ea25a8b26d57ed8eaabff9dc69529618))
+* **workflows:** add test coverage output to ci workflow ([8cfe138](https://github.com/flex-development/tutils/commit/8cfe13836b494a6be840bb869cb5389c75c35236))
+* **workflows:** add test coverage output to ci workflow ([4d7d787](https://github.com/flex-development/tutils/commit/4d7d78736eb4ff3945e7ef5854c3e222c584d22f))
+* **workflows:** cleanup ci workflow ([712557c](https://github.com/flex-development/tutils/commit/712557c6a7f8c79b1c18173241ba79b2fe73011a))
+* **workflows:** cleanup workflow environments and options ([39246d3](https://github.com/flex-development/tutils/commit/39246d3b7b152882c85a85d3c995d257c750adee))
+* **workflows:** fix [@dependabot](https://github.com/dependabot) package ecosystem conditionals ([070cba5](https://github.com/flex-development/tutils/commit/070cba5fc19096f095396dbd4e03329628847f7f))
+* **workflows:** refactor `integrity` ([2eb58c0](https://github.com/flex-development/tutils/commit/2eb58c06f3137292fa7262b65b615cc52e069d8b))
+* **workflows:** remove `query-linked-issues` ([eacd6f9](https://github.com/flex-development/tutils/commit/eacd6f9a37cb66af251228e937278d67ac63efb1))
+* **workflows:** run ci workflow on push to feature and hotfix branches ([c23029a](https://github.com/flex-development/tutils/commit/c23029ae6be2fb00292d8d9bc4f06fd333186724))
+* **workflows:** sign [@dependabot](https://github.com/dependabot) lockfile fix commits ([e16048a](https://github.com/flex-development/tutils/commit/e16048a1a67abb2b5d6f5f632a7845e2120c5cbe))
+* **workflows:** skip `integrity` for [@dependabot](https://github.com/dependabot) ([5b2aba2](https://github.com/flex-development/tutils/commit/5b2aba2fbd70d068fe84b425826766d7993e19d8))
+* **workflows:** skip ci workflow when [@dependabot](https://github.com/dependabot) pushes to `main` ([1a646fb](https://github.com/flex-development/tutils/commit/1a646fbf78b6191d461e534b387445f826c87a54))
+* **workflows:** sync workflow and job names ([b52337a](https://github.com/flex-development/tutils/commit/b52337a8442d476ace665d5606a3bf0e07533d69))
+* **workflows:** try using `secrets.PAT_ADMIN` to trigger pr synchronize event for [@dependabot](https://github.com/dependabot) ([05d88e5](https://github.com/flex-development/tutils/commit/05d88e5c5313b99623d3aca0e10f50047083d1b9))
+* **workflows:** update prerelease check ([178a617](https://github.com/flex-development/tutils/commit/178a6176d2094b44e3ec602f85e9e97661fd42ea))
+* **workflows:** use `secrets.PAT_BOT` ([071ef4d](https://github.com/flex-development/tutils/commit/071ef4dab79be1c67dc0b704a4a7890e84395f24))
+
+
+### :pencil: Documentation
+
+* zsh ([1fe945f](https://github.com/flex-development/tutils/commit/1fe945f7bdeeaca807027ad798433c6bdc46fc2f))
+* **github:** update commit scope descriptions ([a85a7d8](https://github.com/flex-development/tutils/commit/a85a7d830b6d051ec9a1924c64f17d3ae173cdbd))
+
+
+### :house_with_garden: Housekeeping
+
+* cleanup ([4064cb7](https://github.com/flex-development/tutils/commit/4064cb7d1d636dbd945b358aacc09b7bbdd086a0))
+* cleanup cspell dictionary ([0a9659f](https://github.com/flex-development/tutils/commit/0a9659ff4e7ef07d9e6de95c12473faa37ec30fc))
+* cleanup eslint config ([3821ca4](https://github.com/flex-development/tutils/commit/3821ca4f5c4163f3170d39cef0df37102e7cdec0))
+* eslint x graphql support ([eb52b2e](https://github.com/flex-development/tutils/commit/eb52b2ee4a022fa5be87b96faddcc44a2fe7c49c))
+* fix private registry login for [@dependabot](https://github.com/dependabot) ([378917c](https://github.com/flex-development/tutils/commit/378917c9bb7f226ce1dd24259c7b2b1f5c30bd45))
+* only run checks in lint-staged config ([172d10c](https://github.com/flex-development/tutils/commit/172d10c6ca63879baf86bf7a48307b3f98f3a619))
+* only run checks in lint-staged config ([ae7f0db](https://github.com/flex-development/tutils/commit/ae7f0dbb73e455462cc6b85c1cef4757c6f8d40a))
+* remove duplicate `**/.npmignore` entry from `.prettierignore` ([9210257](https://github.com/flex-development/tutils/commit/9210257691971586e729aa0783ba99fd18f0a92f))
+* set specific time for version checks by [@dependabot](https://github.com/dependabot) ([cf428a8](https://github.com/flex-development/tutils/commit/cf428a820dd50700c5a8584f1fda6f02a62fe2db))
+* update jsx check in eslint config ([f366f2f](https://github.com/flex-development/tutils/commit/f366f2f334ab84ca7412ff878b87cba377abf5fd))
+* update sample gitconfig ([246a401](https://github.com/flex-development/tutils/commit/246a401cdcd20b34de19544f074649dace058bd1))
+* **github:** add label `scope:tests` ([35909a1](https://github.com/flex-development/tutils/commit/35909a138f222d7457cadb56932680ce5923b9b0))
+* **github:** configure issue template chooser ([f9746d2](https://github.com/flex-development/tutils/commit/f9746d2941641c3c4045164c1ed20d7f18ddab90))
+* **github:** convert issue templates to issue forms ([a741573](https://github.com/flex-development/tutils/commit/a7415736adb05f474008c4677148809782f3970e))
+* **github:** remove `type:discussion` label ([3aa5bc3](https://github.com/flex-development/tutils/commit/3aa5bc330ac894d7290fb408738a993b66730417))
+* **github:** rename label `scope:deps` to `scope:dependencies` ([198561e](https://github.com/flex-development/tutils/commit/198561ec3048d1eeeb08c341a9b281efb8f3e486))
+* **github:** rename label `scope:typescript` to `scope:ts` ([f9b6530](https://github.com/flex-development/tutils/commit/f9b6530641a58d6c3f594f22e8619d7bebbcf912))
+* **github:** update label descriptions ([74ba0e8](https://github.com/flex-development/tutils/commit/74ba0e81b1f92bb09b793bf36207885076dd8a8d))
+* **github:** update pull request template ([bebd4e2](https://github.com/flex-development/tutils/commit/bebd4e29fe55547a116237dfc289f5996f993462))
+* **release:** read tag prefix from `package.json` ([6b08e88](https://github.com/flex-development/tutils/commit/6b08e882434485d9378ae624db30560a6f0d3322))
+* **release:** update commit message format ([9aa4449](https://github.com/flex-development/tutils/commit/9aa4449f2eda18c9a2d943b3968392dcaad02167))
+* **release:** use current date as release date ([43a2225](https://github.com/flex-development/tutils/commit/43a2225be34125784d14b5b277b7066f20b5600c))
+* **vscode:** cleanup eslint settings ([53571ab](https://github.com/flex-development/tutils/commit/53571ab5047fd2beb3df85411ac3212a03cbf7bd))
+* **vscode:** let prettier handle shellscript files ([118cde5](https://github.com/flex-development/tutils/commit/118cde5b118205cfb5f75cd6bd9743a1ba9c9df6))
+* **yarn:** configure `flex-development` scope ([d24d03e](https://github.com/flex-development/tutils/commit/d24d03ea7a014c72f396e7052d645ddabb31f611))
+* **yarn:** fix lockfile ruined by [@dependabot](https://github.com/dependabot) ([d73bba2](https://github.com/flex-development/tutils/commit/d73bba26ea60a050c606dce97026b091ec56c4ad))
+* **yarn:** fix lockfile ruined by [@dependabot](https://github.com/dependabot) ([87574e4](https://github.com/flex-development/tutils/commit/87574e4836c5fe0bf8fab98106049da9533fb024))
+* **yarn:** fix lockfile ruined by [@dependabot](https://github.com/dependabot) ([705612d](https://github.com/flex-development/tutils/commit/705612d822f3dfaeabe12dcc76d305c30314594d))
+* **yarn:** remove registry restrictions ([793a0ca](https://github.com/flex-development/tutils/commit/793a0cad95fd78b9c91425f771e1e330c474462b))
+
+
+### :white_check_mark: Testing
+
+* update vitest environment ([8b79d00](https://github.com/flex-development/tutils/commit/8b79d004cb6ef40e0e395ee80acbd9d4b1ab3e94))
+
 ## [tutils@5.0.0](https://github.com/flex-development/tutils/compare/tutils@5.0.0-alpha.1...tutils@5.0.0) (2022-08-17)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flex-development/tutils",
   "description": "TypeScript utilities",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "keywords": [
     "enums",
     "interfaces",


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

- bumped version to `tutils@5.0.1`
- added `CHANGELOG` entry for `tutils@5.0.1`

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

### `yarn test:cov`

```zsh
 RUN  v0.23.4
      Coverage enabled with c8

 ✓ src/guards/__tests__/is-unix-timestamp.spec.ts > unit:guards/isUnixTimestamp > should return false given [null]
 ✓ src/guards/__tests__/is-unix-timestamp.spec.ts > unit:guards/isUnixTimestamp > should return true given [1664567391503]
 ✓ src/guards/__tests__/is-empty-value.functional.spec.ts > functional:guards/isEmptyValue > should call isEmptyString 1 time and isNIL 0 times given [""]
 ✓ src/guards/__tests__/is-empty-value.functional.spec.ts > functional:guards/isEmptyValue > should call isEmptyString 1 time and isNIL 0 times given ["   "]
 ✓ src/guards/__tests__/is-empty-value.functional.spec.ts > functional:guards/isEmptyValue > should call isEmptyString 1 time and isNIL 1 time given [null]
 ✓ src/guards/__tests__/is-empty-value.functional.spec.ts > functional:guards/isEmptyValue > should call isEmptyString 1 time and isNIL 1 time given [undefined]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given [[]]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given [{}]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given [13]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given [false]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given ["hello world"]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return true given [""]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return true given ["   "]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return false given ["ci"]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return false given ["DEV"]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return true given ["development"]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return true given ["production"]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return true given ["test"]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return false given [[]]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return false given [{}]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return false given [13]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return true given [true]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return true given ["true"]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return true given [false]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return true given ["false"]
 ✓ src/guards/__tests__/is-jwt-type.spec.ts > unit:guards/isJwtType > should return false given ["EMAIL"]
 ✓ src/guards/__tests__/is-jwt-type.spec.ts > unit:guards/isJwtType > should return true given ["ACCESS"]
 ✓ src/guards/__tests__/is-jwt-type.spec.ts > unit:guards/isJwtType > should return true given ["REFRESH"]
 ✓ src/guards/__tests__/is-jwt-type.spec.ts > unit:guards/isJwtType > should return true given ["VERIFICATION"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return false given ["cd"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return false given ["PROD"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["ci"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["development"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["staging"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["production"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["test"]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [[]]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [{}]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [13]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [true]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [false]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given ["string"]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return true given [null]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return true given [undefined]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return false given [[]]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return false given [{}]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return false given [true]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return false given [false]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return true given [13]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return true given ["hello world"]

Test Files  9 passed (9)
     Tests  50 passed (50)
  Start at  15:49:47
  Duration  4.43s (transform 455ms, setup 5.63s, collect 180ms, tests 66ms)

 % Coverage report from c8
-----------------------|---------|----------|---------|---------|-------------------
File                   | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------|---------|----------|---------|---------|-------------------
All files              |   50.62 |       72 |   53.33 |   50.62 |                   
 enums                 |    23.8 |    33.33 |       0 |    23.8 |                   
  app-env.ts           |     100 |      100 |     100 |     100 |                   
  bson-type-alias.ts   |       0 |        0 |       0 |       0 | 1-22              
  bson-type-code.ts    |       0 |        0 |       0 |       0 | 1-22              
  compare-result.ts    |       0 |        0 |       0 |       0 | 1-21              
  http-status.ts       |       0 |        0 |       0 |       0 | 1-77              
  jwt-type.ts          |     100 |      100 |     100 |     100 |                   
  node-env.ts          |     100 |      100 |     100 |     100 |                   
  project-rule.ts      |       0 |        0 |       0 |       0 | 1-16              
  sort-order.ts        |       0 |        0 |       0 |       0 | 1-18              
 guards                |   87.95 |    93.75 |   88.88 |   87.95 |                   
  is-app-env.ts        |     100 |      100 |     100 |     100 |                   
  is-booleanish.ts     |     100 |      100 |     100 |     100 |                   
  is-empty-string.ts   |     100 |      100 |     100 |     100 |                   
  is-empty-value.ts    |     100 |      100 |     100 |     100 |                   
  is-jwt-type.ts       |     100 |      100 |     100 |     100 |                   
  is-nil.ts            |     100 |      100 |     100 |     100 |                   
  is-node-env.ts       |     100 |      100 |     100 |     100 |                   
  is-number-string.ts  |     100 |      100 |     100 |     100 |                   
  is-unix-timestamp.ts |       0 |        0 |       0 |       0 | 1-20              
-----------------------|---------|----------|---------|---------|-------------------
```

### `yarn build`

```zsh
ℹ Building @flex-development/tutils                                                                 15:53:54
✔ Build succeeded for @flex-development/tutils                                                      15:54:00
  dist (total size: 58.3 kB)                                                                        15:54:00
  └─ dist/index.mjs.map (116 B)
  └─ dist/index.mjs (76 B)
  └─ dist/index.d.mts (131 B)
  └─ dist/enums/app-env.mjs.map (274 B)
  └─ dist/enums/app-env.mjs (302 B)
  └─ dist/enums/app-env.d.mts (283 B)
  └─ dist/enums/bson-type-alias.mjs.map (312 B)
  └─ dist/enums/bson-type-alias.mjs (423 B)
  └─ dist/enums/bson-type-alias.d.mts (432 B)
  └─ dist/enums/bson-type-code.mjs.map (345 B)
  └─ dist/enums/bson-type-code.mjs (528 B)
  └─ dist/enums/bson-type-code.d.mts (390 B)
  └─ dist/enums/compare-result.mjs.map (267 B)
  └─ dist/enums/compare-result.mjs (395 B)
  └─ dist/enums/compare-result.d.mts (445 B)
  └─ dist/enums/http-status.mjs.map (1.94 kB)
  └─ dist/enums/http-status.mjs (4.61 kB)
  └─ dist/enums/http-status.d.mts (1.89 kB)
  └─ dist/enums/index.mjs.map (328 B)
  └─ dist/enums/index.mjs (722 B)
  └─ dist/enums/index.d.mts (554 B)
  └─ dist/enums/jwt-type.mjs.map (235 B)
  └─ dist/enums/jwt-type.mjs (272 B)
  └─ dist/enums/jwt-type.d.mts (291 B)
  └─ dist/enums/node-env.mjs.map (234 B)
  └─ dist/enums/node-env.mjs (258 B)
  └─ dist/enums/node-env.d.mts (244 B)
  └─ dist/enums/project-rule.mjs.map (234 B)
  └─ dist/enums/project-rule.mjs (289 B)
  └─ dist/enums/project-rule.d.mts (253 B)
  └─ dist/enums/sort-order.mjs.map (230 B)
  └─ dist/enums/sort-order.mjs (290 B)
  └─ dist/enums/sort-order.d.mts (333 B)
  └─ dist/guards/index.mjs.map (304 B)
  └─ dist/guards/index.mjs (665 B)
  └─ dist/guards/index.d.mts (530 B)
  └─ dist/guards/is-app-env.mjs.map (206 B)
  └─ dist/guards/is-app-env.mjs (201 B)
  └─ dist/guards/is-app-env.d.mts (357 B)
  └─ dist/guards/is-booleanish.mjs.map (193 B)
  └─ dist/guards/is-booleanish.mjs (204 B)
  └─ dist/guards/is-booleanish.d.mts (397 B)
  └─ dist/guards/is-empty-string.mjs.map (202 B)
  └─ dist/guards/is-empty-string.mjs (198 B)
  └─ dist/guards/is-empty-string.d.mts (324 B)
  └─ dist/guards/is-empty-value.mjs.map (223 B)
  └─ dist/guards/is-empty-value.mjs (252 B)
  └─ dist/guards/is-empty-value.d.mts (404 B)
  └─ dist/guards/is-jwt-type.mjs.map (208 B)
  └─ dist/guards/is-jwt-type.mjs (208 B)
  └─ dist/guards/is-jwt-type.d.mts (357 B)
  └─ dist/guards/is-nil.mjs.map (171 B)
  └─ dist/guards/is-nil.mjs (143 B)
  └─ dist/guards/is-nil.d.mts (336 B)
  └─ dist/guards/is-node-env.mjs.map (214 B)
  └─ dist/guards/is-node-env.mjs (224 B)
  └─ dist/guards/is-node-env.d.mts (386 B)
  └─ dist/guards/is-number-string.mjs.map (193 B)
  └─ dist/guards/is-number-string.mjs (201 B)
  └─ dist/guards/is-number-string.d.mts (400 B)
  └─ dist/guards/is-unix-timestamp.mjs.map (214 B)
  └─ dist/guards/is-unix-timestamp.mjs (221 B)
  └─ dist/guards/is-unix-timestamp.d.mts (410 B)
  └─ dist/types/any.mjs.map (69 B)
  └─ dist/types/any.mjs (0 B)
  └─ dist/types/any.d.mts (164 B)
  └─ dist/types/booleanish.mjs.map (69 B)
  └─ dist/types/booleanish.mjs (0 B)
  └─ dist/types/booleanish.d.mts (244 B)
  └─ dist/types/built-in.mjs.map (69 B)
  └─ dist/types/built-in.mjs (0 B)
  └─ dist/types/built-in.d.mts (251 B)
  └─ dist/types/class-constructor.mjs.map (69 B)
  └─ dist/types/class-constructor.mjs (0 B)
  └─ dist/types/class-constructor.d.mts (488 B)
  └─ dist/types/comparison-operator.mjs.map (69 B)
  └─ dist/types/comparison-operator.mjs (0 B)
  └─ dist/types/comparison-operator.d.mts (272 B)
  └─ dist/types/continuous-value.mjs.map (69 B)
  └─ dist/types/continuous-value.mjs (0 B)
  └─ dist/types/continuous-value.d.mts (283 B)
  └─ dist/types/deep-omit.mjs.map (69 B)
  └─ dist/types/deep-omit.mjs (0 B)
  └─ dist/types/deep-omit.d.mts (2.51 kB)
  └─ dist/types/deep-partial.mjs.map (69 B)
  └─ dist/types/deep-partial.mjs (0 B)
  └─ dist/types/deep-partial.d.mts (1.13 kB)
  └─ dist/types/deep-pick.mjs.map (69 B)
  └─ dist/types/deep-pick.mjs (0 B)
  └─ dist/types/deep-pick.d.mts (760 B)
  └─ dist/types/deep-required.mjs.map (69 B)
  └─ dist/types/deep-required.mjs (0 B)
  └─ dist/types/deep-required.d.mts (1.06 kB)
  └─ dist/types/document-partial.mjs.map (69 B)
  └─ dist/types/document-partial.mjs (0 B)
  └─ dist/types/document-partial.d.mts (797 B)
  └─ dist/types/duid.mjs.map (69 B)
  └─ dist/types/duid.mjs (0 B)
  └─ dist/types/duid.d.mts (195 B)
  └─ dist/types/empty-string.mjs.map (69 B)
  └─ dist/types/empty-string.mjs (0 B)
  └─ dist/types/empty-string.d.mts (201 B)
  └─ dist/types/empty-value.mjs.map (69 B)
  └─ dist/types/empty-value.mjs (0 B)
  └─ dist/types/empty-value.d.mts (312 B)
  └─ dist/types/fixme.mjs.map (69 B)
  └─ dist/types/fixme.mjs (0 B)
  └─ dist/types/fixme.d.mts (210 B)
  └─ dist/types/index-signature.mjs.map (69 B)
  └─ dist/types/index-signature.mjs (0 B)
  └─ dist/types/index-signature.d.mts (308 B)
  └─ dist/types/index.mjs.map (69 B)
  └─ dist/types/index.mjs (0 B)
  └─ dist/types/index.d.mts (3.42 kB)
  └─ dist/types/intersection.mjs.map (69 B)
  └─ dist/types/intersection.mjs (0 B)
  └─ dist/types/intersection.d.mts (404 B)
  └─ dist/types/is-tuple.mjs.map (69 B)
  └─ dist/types/is-tuple.mjs (0 B)
  └─ dist/types/is-tuple.d.mts (515 B)
  └─ dist/types/join.mjs.map (69 B)
  └─ dist/types/join.mjs (0 B)
  └─ dist/types/join.d.mts (506 B)
  └─ dist/types/json-array.mjs.map (69 B)
  └─ dist/types/json-array.mjs (0 B)
  └─ dist/types/json-array.d.mts (316 B)
  └─ dist/types/json-object.mjs.map (69 B)
  └─ dist/types/json-object.mjs (0 B)
  └─ dist/types/json-object.d.mts (760 B)
  └─ dist/types/json-primitive.mjs.map (69 B)
  └─ dist/types/json-primitive.mjs (0 B)
  └─ dist/types/json-primitive.d.mts (370 B)
  └─ dist/types/json-value.mjs.map (69 B)
  └─ dist/types/json-value.mjs (0 B)
  └─ dist/types/json-value.d.mts (405 B)
  └─ dist/types/keys-optional.mjs.map (69 B)
  └─ dist/types/keys-optional.mjs (0 B)
  └─ dist/types/keys-optional.d.mts (467 B)
  └─ dist/types/keys-required.mjs.map (69 B)
  └─ dist/types/keys-required.mjs (0 B)
  └─ dist/types/keys-required.d.mts (444 B)
  └─ dist/types/nil.mjs.map (69 B)
  └─ dist/types/nil.mjs (0 B)
  └─ dist/types/nil.d.mts (197 B)
  └─ dist/types/nullable.mjs.map (69 B)
  └─ dist/types/nullable.mjs (0 B)
  └─ dist/types/nullable.d.mts (256 B)
  └─ dist/types/nullish-boolean.mjs.map (69 B)
  └─ dist/types/nullish-boolean.mjs (0 B)
  └─ dist/types/nullish-boolean.d.mts (245 B)
  └─ dist/types/nullish-number.mjs.map (69 B)
  └─ dist/types/nullish-number.mjs (0 B)
  └─ dist/types/nullish-number.d.mts (239 B)
  └─ dist/types/nullish-string.mjs.map (69 B)
  └─ dist/types/nullish-string.mjs (0 B)
  └─ dist/types/nullish-string.d.mts (239 B)
  └─ dist/types/number-like.mjs.map (69 B)
  └─ dist/types/number-like.mjs (0 B)
  └─ dist/types/number-like.d.mts (263 B)
  └─ dist/types/number-string.mjs.map (69 B)
  └─ dist/types/number-string.mjs (0 B)
  └─ dist/types/number-string.d.mts (225 B)
  └─ dist/types/numeric.mjs.map (69 B)
  └─ dist/types/numeric.mjs (0 B)
  └─ dist/types/numeric.d.mts (196 B)
  └─ dist/types/object-empty.mjs.map (69 B)
  └─ dist/types/object-empty.mjs (0 B)
  └─ dist/types/object-empty.d.mts (221 B)
  └─ dist/types/object-plain.mjs.map (69 B)
  └─ dist/types/object-plain.mjs (0 B)
  └─ dist/types/object-plain.d.mts (304 B)
  └─ dist/types/object-unknown.mjs.map (69 B)
  └─ dist/types/object-unknown.mjs (0 B)
  └─ dist/types/object-unknown.d.mts (297 B)
  └─ dist/types/omit-by-type.mjs.map (69 B)
  └─ dist/types/omit-by-type.mjs (0 B)
  └─ dist/types/omit-by-type.d.mts (451 B)
  └─ dist/types/one-or-many.mjs.map (69 B)
  └─ dist/types/one-or-many.mjs (0 B)
  └─ dist/types/one-or-many.d.mts (253 B)
  └─ dist/types/or-deep-partial.mjs.map (69 B)
  └─ dist/types/or-deep-partial.mjs (0 B)
  └─ dist/types/or-deep-partial.d.mts (367 B)
  └─ dist/types/or-never.mjs.map (69 B)
  └─ dist/types/or-never.mjs (0 B)
  └─ dist/types/or-never.d.mts (325 B)
  └─ dist/types/or-nil.mjs.map (69 B)
  └─ dist/types/or-nil.mjs (0 B)
  └─ dist/types/or-nil.d.mts (257 B)
  └─ dist/types/or-null.mjs.map (69 B)
  └─ dist/types/or-null.mjs (0 B)
  └─ dist/types/or-null.d.mts (233 B)
  └─ dist/types/or-partial.mjs.map (69 B)
  └─ dist/types/or-partial.mjs (0 B)
  └─ dist/types/or-partial.d.mts (300 B)
  └─ dist/types/or-promise.mjs.map (69 B)
  └─ dist/types/or-promise.mjs (0 B)
  └─ dist/types/or-promise.d.mts (260 B)
  └─ dist/types/or-undefined.mjs.map (69 B)
  └─ dist/types/or-undefined.mjs (0 B)
  └─ dist/types/or-undefined.d.mts (263 B)
  └─ dist/types/overwrite.mjs.map (69 B)
  └─ dist/types/overwrite.mjs (0 B)
  └─ dist/types/overwrite.d.mts (461 B)
  └─ dist/types/path-n.mjs.map (69 B)
  └─ dist/types/path-n.mjs (0 B)
  └─ dist/types/path-n.d.mts (691 B)
  └─ dist/types/path-nt.mjs.map (69 B)
  └─ dist/types/path-nt.mjs (0 B)
  └─ dist/types/path-nt.d.mts (476 B)
  └─ dist/types/path-value.mjs.map (69 B)
  └─ dist/types/path-value.mjs (0 B)
  └─ dist/types/path-value.d.mts (694 B)
  └─ dist/types/path.mjs.map (69 B)
  └─ dist/types/path.mjs (0 B)
  └─ dist/types/path.d.mts (540 B)
  └─ dist/types/pick-by-type.mjs.map (69 B)
  └─ dist/types/pick-by-type.mjs (0 B)
  └─ dist/types/pick-by-type.d.mts (450 B)
  └─ dist/types/primitive.mjs.map (69 B)
  └─ dist/types/primitive.mjs (0 B)
  └─ dist/types/primitive.d.mts (359 B)
  └─ dist/types/regex-string.mjs.map (69 B)
  └─ dist/types/regex-string.mjs (0 B)
  └─ dist/types/regex-string.d.mts (234 B)
  └─ dist/types/split.mjs.map (69 B)
  └─ dist/types/split.mjs (0 B)
  └─ dist/types/split.d.mts (431 B)
  └─ dist/types/string-like.mjs.map (69 B)
  └─ dist/types/string-like.mjs (0 B)
  └─ dist/types/string-like.d.mts (229 B)
  └─ dist/types/timestamp-unix.mjs.map (69 B)
  └─ dist/types/timestamp-unix.mjs (0 B)
  └─ dist/types/timestamp-unix.d.mts (279 B)
  └─ dist/types/uid.mjs.map (69 B)
  └─ dist/types/uid.mjs (0 B)
  └─ dist/types/uid.d.mts (231 B)
  └─ dist/types/union.mjs.map (69 B)
  └─ dist/types/union.mjs (0 B)
  └─ dist/types/union.d.mts (464 B)
  dist (total size: 127 kB)                                                                         15:54:00
  └─ dist/index.cjs.map (161 B)
  └─ dist/index.cjs (1.05 kB)
  └─ dist/index.d.cts (131 B)
  └─ dist/enums/app-env.cjs.map (316 B)
  └─ dist/enums/app-env.cjs (1.19 kB)
  └─ dist/enums/app-env.d.cts (283 B)
  └─ dist/enums/bson-type-alias.cjs.map (354 B)
  └─ dist/enums/bson-type-alias.cjs (1.33 kB)
  └─ dist/enums/bson-type-alias.d.cts (432 B)
  └─ dist/enums/bson-type-code.cjs.map (387 B)
  └─ dist/enums/bson-type-code.cjs (1.43 kB)
  └─ dist/enums/bson-type-code.d.cts (390 B)
  └─ dist/enums/compare-result.cjs.map (309 B)
  └─ dist/enums/compare-result.cjs (1.3 kB)
  └─ dist/enums/compare-result.d.cts (445 B)
  └─ dist/enums/http-status.cjs.map (1.99 kB)
  └─ dist/enums/http-status.cjs (5.51 kB)
  └─ dist/enums/http-status.d.cts (1.89 kB)
  └─ dist/enums/index.cjs.map (299 B)
  └─ dist/enums/index.cjs (2.19 kB)
  └─ dist/enums/index.d.cts (554 B)
  └─ dist/enums/jwt-type.cjs.map (277 B)
  └─ dist/enums/jwt-type.cjs (1.16 kB)
  └─ dist/enums/jwt-type.d.cts (291 B)
  └─ dist/enums/node-env.cjs.map (276 B)
  └─ dist/enums/node-env.cjs (1.14 kB)
  └─ dist/enums/node-env.d.cts (244 B)
  └─ dist/enums/project-rule.cjs.map (276 B)
  └─ dist/enums/project-rule.cjs (1.19 kB)
  └─ dist/enums/project-rule.d.cts (253 B)
  └─ dist/enums/sort-order.cjs.map (272 B)
  └─ dist/enums/sort-order.cjs (1.18 kB)
  └─ dist/enums/sort-order.d.cts (333 B)
  └─ dist/guards/index.cjs.map (282 B)
  └─ dist/guards/index.cjs (2.14 kB)
  └─ dist/guards/index.d.cts (530 B)
  └─ dist/guards/is-app-env.cjs.map (265 B)
  └─ dist/guards/is-app-env.cjs (1.44 kB)
  └─ dist/guards/is-app-env.d.cts (357 B)
  └─ dist/guards/is-booleanish.cjs.map (235 B)
  └─ dist/guards/is-booleanish.cjs (1.1 kB)
  └─ dist/guards/is-booleanish.d.cts (397 B)
  └─ dist/guards/is-empty-string.cjs.map (244 B)
  └─ dist/guards/is-empty-string.cjs (1.1 kB)
  └─ dist/guards/is-empty-string.d.cts (324 B)
  └─ dist/guards/is-empty-value.cjs.map (300 B)
  └─ dist/guards/is-empty-value.cjs (1.56 kB)
  └─ dist/guards/is-empty-value.d.cts (404 B)
  └─ dist/guards/is-jwt-type.cjs.map (269 B)
  └─ dist/guards/is-jwt-type.cjs (1.45 kB)
  └─ dist/guards/is-jwt-type.d.cts (357 B)
  └─ dist/guards/is-nil.cjs.map (213 B)
  └─ dist/guards/is-nil.cjs (1.02 kB)
  └─ dist/guards/is-nil.d.cts (336 B)
  └─ dist/guards/is-node-env.cjs.map (275 B)
  └─ dist/guards/is-node-env.cjs (1.47 kB)
  └─ dist/guards/is-node-env.d.cts (386 B)
  └─ dist/guards/is-number-string.cjs.map (235 B)
  └─ dist/guards/is-number-string.cjs (1.11 kB)
  └─ dist/guards/is-number-string.d.cts (400 B)
  └─ dist/guards/is-unix-timestamp.cjs.map (256 B)
  └─ dist/guards/is-unix-timestamp.cjs (1.13 kB)
  └─ dist/guards/is-unix-timestamp.d.cts (410 B)
  └─ dist/types/any.cjs.map (116 B)
  └─ dist/types/any.cjs (723 B)
  └─ dist/types/any.d.cts (164 B)
  └─ dist/types/booleanish.cjs.map (123 B)
  └─ dist/types/booleanish.cjs (737 B)
  └─ dist/types/booleanish.d.cts (244 B)
  └─ dist/types/built-in.cjs.map (121 B)
  └─ dist/types/built-in.cjs (733 B)
  └─ dist/types/built-in.d.cts (251 B)
  └─ dist/types/class-constructor.cjs.map (130 B)
  └─ dist/types/class-constructor.cjs (751 B)
  └─ dist/types/class-constructor.d.cts (488 B)
  └─ dist/types/comparison-operator.cjs.map (132 B)
  └─ dist/types/comparison-operator.cjs (755 B)
  └─ dist/types/comparison-operator.d.cts (272 B)
  └─ dist/types/continuous-value.cjs.map (129 B)
  └─ dist/types/continuous-value.cjs (749 B)
  └─ dist/types/continuous-value.d.cts (283 B)
  └─ dist/types/deep-omit.cjs.map (122 B)
  └─ dist/types/deep-omit.cjs (735 B)
  └─ dist/types/deep-omit.d.cts (2.51 kB)
  └─ dist/types/deep-partial.cjs.map (125 B)
  └─ dist/types/deep-partial.cjs (741 B)
  └─ dist/types/deep-partial.d.cts (1.13 kB)
  └─ dist/types/deep-pick.cjs.map (122 B)
  └─ dist/types/deep-pick.cjs (735 B)
  └─ dist/types/deep-pick.d.cts (760 B)
  └─ dist/types/deep-required.cjs.map (126 B)
  └─ dist/types/deep-required.cjs (743 B)
  └─ dist/types/deep-required.d.cts (1.06 kB)
  └─ dist/types/document-partial.cjs.map (129 B)
  └─ dist/types/document-partial.cjs (749 B)
  └─ dist/types/document-partial.d.cts (797 B)
  └─ dist/types/duid.cjs.map (117 B)
  └─ dist/types/duid.cjs (725 B)
  └─ dist/types/duid.d.cts (195 B)
  └─ dist/types/empty-string.cjs.map (125 B)
  └─ dist/types/empty-string.cjs (741 B)
  └─ dist/types/empty-string.d.cts (201 B)
  └─ dist/types/empty-value.cjs.map (124 B)
  └─ dist/types/empty-value.cjs (739 B)
  └─ dist/types/empty-value.d.cts (312 B)
  └─ dist/types/fixme.cjs.map (118 B)
  └─ dist/types/fixme.cjs (727 B)
  └─ dist/types/fixme.d.cts (210 B)
  └─ dist/types/index-signature.cjs.map (128 B)
  └─ dist/types/index-signature.cjs (747 B)
  └─ dist/types/index-signature.d.cts (308 B)
  └─ dist/types/index.cjs.map (118 B)
  └─ dist/types/index.cjs (727 B)
  └─ dist/types/index.d.cts (3.42 kB)
  └─ dist/types/intersection.cjs.map (125 B)
  └─ dist/types/intersection.cjs (741 B)
  └─ dist/types/intersection.d.cts (404 B)
  └─ dist/types/is-tuple.cjs.map (121 B)
  └─ dist/types/is-tuple.cjs (733 B)
  └─ dist/types/is-tuple.d.cts (515 B)
  └─ dist/types/join.cjs.map (117 B)
  └─ dist/types/join.cjs (725 B)
  └─ dist/types/join.d.cts (506 B)
  └─ dist/types/json-array.cjs.map (123 B)
  └─ dist/types/json-array.cjs (737 B)
  └─ dist/types/json-array.d.cts (316 B)
  └─ dist/types/json-object.cjs.map (124 B)
  └─ dist/types/json-object.cjs (739 B)
  └─ dist/types/json-object.d.cts (760 B)
  └─ dist/types/json-primitive.cjs.map (127 B)
  └─ dist/types/json-primitive.cjs (745 B)
  └─ dist/types/json-primitive.d.cts (370 B)
  └─ dist/types/json-value.cjs.map (123 B)
  └─ dist/types/json-value.cjs (737 B)
  └─ dist/types/json-value.d.cts (405 B)
  └─ dist/types/keys-optional.cjs.map (126 B)
  └─ dist/types/keys-optional.cjs (743 B)
  └─ dist/types/keys-optional.d.cts (467 B)
  └─ dist/types/keys-required.cjs.map (126 B)
  └─ dist/types/keys-required.cjs (743 B)
  └─ dist/types/keys-required.d.cts (444 B)
  └─ dist/types/nil.cjs.map (116 B)
  └─ dist/types/nil.cjs (723 B)
  └─ dist/types/nil.d.cts (197 B)
  └─ dist/types/nullable.cjs.map (121 B)
  └─ dist/types/nullable.cjs (733 B)
  └─ dist/types/nullable.d.cts (256 B)
  └─ dist/types/nullish-boolean.cjs.map (128 B)
  └─ dist/types/nullish-boolean.cjs (747 B)
  └─ dist/types/nullish-boolean.d.cts (245 B)
  └─ dist/types/nullish-number.cjs.map (127 B)
  └─ dist/types/nullish-number.cjs (745 B)
  └─ dist/types/nullish-number.d.cts (239 B)
  └─ dist/types/nullish-string.cjs.map (127 B)
  └─ dist/types/nullish-string.cjs (745 B)
  └─ dist/types/nullish-string.d.cts (239 B)
  └─ dist/types/number-like.cjs.map (124 B)
  └─ dist/types/number-like.cjs (739 B)
  └─ dist/types/number-like.d.cts (263 B)
  └─ dist/types/number-string.cjs.map (126 B)
  └─ dist/types/number-string.cjs (743 B)
  └─ dist/types/number-string.d.cts (225 B)
  └─ dist/types/numeric.cjs.map (120 B)
  └─ dist/types/numeric.cjs (731 B)
  └─ dist/types/numeric.d.cts (196 B)
  └─ dist/types/object-empty.cjs.map (125 B)
  └─ dist/types/object-empty.cjs (741 B)
  └─ dist/types/object-empty.d.cts (221 B)
  └─ dist/types/object-plain.cjs.map (125 B)
  └─ dist/types/object-plain.cjs (741 B)
  └─ dist/types/object-plain.d.cts (304 B)
  └─ dist/types/object-unknown.cjs.map (127 B)
  └─ dist/types/object-unknown.cjs (745 B)
  └─ dist/types/object-unknown.d.cts (297 B)
  └─ dist/types/omit-by-type.cjs.map (125 B)
  └─ dist/types/omit-by-type.cjs (741 B)
  └─ dist/types/omit-by-type.d.cts (451 B)
  └─ dist/types/one-or-many.cjs.map (124 B)
  └─ dist/types/one-or-many.cjs (739 B)
  └─ dist/types/one-or-many.d.cts (253 B)
  └─ dist/types/or-deep-partial.cjs.map (128 B)
  └─ dist/types/or-deep-partial.cjs (747 B)
  └─ dist/types/or-deep-partial.d.cts (367 B)
  └─ dist/types/or-never.cjs.map (121 B)
  └─ dist/types/or-never.cjs (733 B)
  └─ dist/types/or-never.d.cts (325 B)
  └─ dist/types/or-nil.cjs.map (119 B)
  └─ dist/types/or-nil.cjs (729 B)
  └─ dist/types/or-nil.d.cts (257 B)
  └─ dist/types/or-null.cjs.map (120 B)
  └─ dist/types/or-null.cjs (731 B)
  └─ dist/types/or-null.d.cts (233 B)
  └─ dist/types/or-partial.cjs.map (123 B)
  └─ dist/types/or-partial.cjs (737 B)
  └─ dist/types/or-partial.d.cts (300 B)
  └─ dist/types/or-promise.cjs.map (123 B)
  └─ dist/types/or-promise.cjs (737 B)
  └─ dist/types/or-promise.d.cts (260 B)
  └─ dist/types/or-undefined.cjs.map (125 B)
  └─ dist/types/or-undefined.cjs (741 B)
  └─ dist/types/or-undefined.d.cts (263 B)
  └─ dist/types/overwrite.cjs.map (122 B)
  └─ dist/types/overwrite.cjs (735 B)
  └─ dist/types/overwrite.d.cts (461 B)
  └─ dist/types/path-n.cjs.map (119 B)
  └─ dist/types/path-n.cjs (729 B)
  └─ dist/types/path-n.d.cts (691 B)
  └─ dist/types/path-nt.cjs.map (120 B)
  └─ dist/types/path-nt.cjs (731 B)
  └─ dist/types/path-nt.d.cts (476 B)
  └─ dist/types/path-value.cjs.map (123 B)
  └─ dist/types/path-value.cjs (737 B)
  └─ dist/types/path-value.d.cts (694 B)
  └─ dist/types/path.cjs.map (117 B)
  └─ dist/types/path.cjs (725 B)
  └─ dist/types/path.d.cts (540 B)
  └─ dist/types/pick-by-type.cjs.map (125 B)
  └─ dist/types/pick-by-type.cjs (741 B)
  └─ dist/types/pick-by-type.d.cts (450 B)
  └─ dist/types/primitive.cjs.map (122 B)
  └─ dist/types/primitive.cjs (735 B)
  └─ dist/types/primitive.d.cts (359 B)
  └─ dist/types/regex-string.cjs.map (125 B)
  └─ dist/types/regex-string.cjs (741 B)
  └─ dist/types/regex-string.d.cts (234 B)
  └─ dist/types/split.cjs.map (118 B)
  └─ dist/types/split.cjs (727 B)
  └─ dist/types/split.d.cts (431 B)
  └─ dist/types/string-like.cjs.map (124 B)
  └─ dist/types/string-like.cjs (739 B)
  └─ dist/types/string-like.d.cts (229 B)
  └─ dist/types/timestamp-unix.cjs.map (127 B)
  └─ dist/types/timestamp-unix.cjs (745 B)
  └─ dist/types/timestamp-unix.d.cts (279 B)
  └─ dist/types/uid.cjs.map (116 B)
  └─ dist/types/uid.cjs (723 B)
  └─ dist/types/uid.d.cts (231 B)
  └─ dist/types/union.cjs.map (118 B)
  └─ dist/types/union.cjs (727 B)
  └─ dist/types/union.d.cts (464 B)
Σ Total build size: 186 kB                                                                          15:54:00
```

## Additional context

<!-- Add any other information (docs, files, issue references, etc) about the pull request here. -->

N/A

## Linked issues

<!-- closes #[issue number], fixes #[issue number] -->

N/A

## Submission checklist

- [x] self-review performed
- [x] tests added and/or updated
- [x] documentation added or updated
- [x] new, **tolerable** vulnerabilities and/or warnings documented, if any
- [x] [pr naming conventions][1]

[1]: https://github.com/flex-development/tutils/blob/main/CONTRIBUTING.md#pull-request-titles
