### PR TITLE
release: tutils@6.0.0-alpha.1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,7 @@
     "rewrap.wrappingColumn": 130
   },
   "[markdown]": {
-    "editor.defaultFormatter": "DavidAnson.vscode-markdownlint",
+    "editor.defaultFormatter": "vscode.markdown-language-features",
     "editor.rulers": [
       {
         "color": "var(--vscode-editorRuler-foreground)",
@@ -137,9 +137,16 @@
   "files.trimTrailingWhitespace": true,
   "git.autofetch": true,
   "git.enableSmartCommit": true,
-  "markdownlint.ignore": "./.markdownlintignore",
   "markdown.extension.toc.slugifyMode": "github",
   "markdown.extension.toc.updateOnSave": false,
+  "markdownlint.ignore": "./.markdownlintignore",
+  "markdownlint.lintWorkspaceGlobs": [
+    "**/*.md",
+    "!**/node_modules",
+    "!**/.git",
+    "!**/CHANGELOG.md",
+    "!**/LICENSE.md"
+  ],
   "npm-intellisense.scanDevDependencies": true,
   "prettier.enable": false,
   "prettier.useEditorConfig": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,97 @@
+## [tutils@6.0.0-alpha.1](https://github.com/flex-development/tutils/compare/tutils@5.0.1...tutils@6.0.0-alpha.1) (2022-11-23)
+
+
+### ⚠ BREAKING CHANGES
+
+* **exports:** export `.` and `./package.json` only
+* **types:** remove `NumberString`
+* **types:** remove `OmitByType`
+* **types:** remove `RegexString`
+* **types:** remove `DeepPick`
+* **types:** remove `DeepPartial`
+* **types:** remove `Or*`
+* **types:** remove `Nullish*`
+* **types:** `OrNil` -> `Nilable`
+* **types:** remove `Union`
+* **types:** remove `UID`
+* **types:** remove `OrDeepPartial`
+* **types:** remove `PickByType`
+* **types:** remove `Intersection`
+* **types:** remove `DUID`
+* **types:** remove `DocumentPartial`
+* **types:** remove `DeepOmit`
+* **types:** remove `DeepRequired`
+* **types:** `OrPromise` -> `Promisable`
+* **types:** `ClassConstructor` -> `Constructor`
+
+### :package: Build
+
+* require node `>=14.16` ([f4a01a4](https://github.com/flex-development/tutils/commit/f4a01a426c0047830ed3ff46418f37a37ae7a5db))
+* **deps-peer:** add `typescript>=4.7` (optional) ([aa6c1d5](https://github.com/flex-development/tutils/commit/aa6c1d5885a00ac09f5e6ba29afaab8faa0efcba))
+* **exports:** export `.` and `./package.json` only ([cf1edd4](https://github.com/flex-development/tutils/commit/cf1edd4731bca78d2bd694c89b6f0e7e51102c5e))
+
+
+### :robot: Continuous Integration
+
+* **deps:** Bump actions/add-to-project from 0.3.0 to 0.4.0 ([#85](https://github.com/flex-development/tutils/issues/85)) ([da49a5f](https://github.com/flex-development/tutils/commit/da49a5f9ccf3aebc8e85450c4cf0c8a832e0b29b))
+* **deps:** bump actions/checkout from 3.0.2 to 3.1.0 ([#77](https://github.com/flex-development/tutils/issues/77)) ([3a5b4a6](https://github.com/flex-development/tutils/commit/3a5b4a6b97a2464df8e8bc79006071065f9e084b))
+* **deps:** bump actions/github-script from 6.1.1 to 6.3.1 ([#75](https://github.com/flex-development/tutils/issues/75)) ([be9055d](https://github.com/flex-development/tutils/commit/be9055dfe8f857ee31ab86d568d40f1c30b9e197))
+* **deps:** bump actions/github-script from 6.3.1 to 6.3.2 ([#79](https://github.com/flex-development/tutils/issues/79)) ([73bba8a](https://github.com/flex-development/tutils/commit/73bba8a2fd7adf5dab263f665803730c7f07d684))
+* **deps:** bump actions/github-script from 6.3.2 to 6.3.3 ([#81](https://github.com/flex-development/tutils/issues/81)) ([9bbbafd](https://github.com/flex-development/tutils/commit/9bbbafd1e9711ee134ec1a1990a5e8818cfeddca))
+* **deps:** bump actions/setup-node from 3.4.1 to 3.5.0 ([#72](https://github.com/flex-development/tutils/issues/72)) ([19c2491](https://github.com/flex-development/tutils/commit/19c249103f4e7e6e562c15b13134062e5935568d))
+* **deps:** Bump crazy-max/ghaction-import-gpg from 5.1.0 to 5.2.0 ([#83](https://github.com/flex-development/tutils/issues/83)) ([7a3acec](https://github.com/flex-development/tutils/commit/7a3acec213fba2b6fb6c2f0666d83fa79e80d918))
+* **deps:** bump dependabot/fetch-metadata from 1.3.3 to 1.3.4 ([#76](https://github.com/flex-development/tutils/issues/76)) ([87c92b9](https://github.com/flex-development/tutils/commit/87c92b93171f6e839beb2a8bdf257674471295e8))
+* **deps:** Bump dependabot/fetch-metadata from 1.3.4 to 1.3.5 ([#84](https://github.com/flex-development/tutils/issues/84)) ([6eb6090](https://github.com/flex-development/tutils/commit/6eb609027f1173bd74b35de3b02ebff2a2a8fffb))
+* **deps:** bump flex-development/dist-tag-action from 1.1.0 to 1.1.1 ([#73](https://github.com/flex-development/tutils/issues/73)) ([c821b01](https://github.com/flex-development/tutils/commit/c821b014519724bb86320d28c74cf7cc06e54b92))
+* **deps:** bump hmarr/debug-action from 2.0.1 to 2.1.0 ([#78](https://github.com/flex-development/tutils/issues/78)) ([35b6396](https://github.com/flex-development/tutils/commit/35b639648ed7832920901990302cdad132c23764))
+
+
+### :sparkles: Features
+
+* **types:** `Class` ([3dd5638](https://github.com/flex-development/tutils/commit/3dd5638ef89f7c2b7c904fe2e1cc74c71044884b))
+* **types:** `LiteralUnion` ([fc987d3](https://github.com/flex-development/tutils/commit/fc987d34aacb47ac93ddee23a140bdc7a20b8856))
+* **types:** `Opaque` ([5a6fe9b](https://github.com/flex-development/tutils/commit/5a6fe9b563ef0bca722babe94ee7d7c888d8fd80))
+* **types:** `Predicate` ([ed21f07](https://github.com/flex-development/tutils/commit/ed21f07166df17381393847933becc89fb25e576))
+* **types:** `SemanticVersion` ([c3212d9](https://github.com/flex-development/tutils/commit/c3212d987b0fb00eb97999ee3efda5fb19f77f19))
+* **types:** `Simplify` ([29d5151](https://github.com/flex-development/tutils/commit/29d51519d69948d61e2d92a6ddf13b1f99e1031a))
+
+
+### :bug: Fixes
+
+* **cjs:** missing `default` exports ([4d2d9fc](https://github.com/flex-development/tutils/commit/4d2d9fcae7818217e55fc4ab04781dc81ba87534))
+
+
+### :house_with_garden: Housekeeping
+
+* cleanup eslint overrides ([10d28ee](https://github.com/flex-development/tutils/commit/10d28eeef001afc78ffc33c363adff24ad5a11d4))
+* ensure all eslint overrides are in config file ([e19f58a](https://github.com/flex-development/tutils/commit/e19f58a9856a030c81b667043dbca765a74e7a15))
+* update project architecture ([c2b2c41](https://github.com/flex-development/tutils/commit/c2b2c41a7c4fa80e61a130a1d72e8dc01ed4e7d4))
+
+
+### :zap: Refactors
+
+* **types:** `KeysOptional` logic ([4ccae04](https://github.com/flex-development/tutils/commit/4ccae046cd08577bc3c67c8c1536f8f09a3abb46))
+* **types:** `KeysRequired` logic ([23aab45](https://github.com/flex-development/tutils/commit/23aab452896b531ee257017a1d6555ae9c82d3f1))
+* **types:** `ClassConstructor` -> `Constructor` ([f6d8af2](https://github.com/flex-development/tutils/commit/f6d8af25983c23a2e55337b8cff4470e9ee05b98))
+* **types:** `OrNil` -> `Nilable` ([b0c17d7](https://github.com/flex-development/tutils/commit/b0c17d7dc0679f4bfbff554b86b48aff2ec30b08))
+* **types:** `OrPromise` -> `Promisable` ([a6f25d1](https://github.com/flex-development/tutils/commit/a6f25d19f1dc58414365b27f0dbaa66514f03712))
+* **types:** remove `DeepOmit` ([9617b62](https://github.com/flex-development/tutils/commit/9617b6299455f16252918d9aa7409a91824c7c2b))
+* **types:** remove `DeepPartial` ([d632b7a](https://github.com/flex-development/tutils/commit/d632b7a16011cbdfebe055b51eefaa0749424080))
+* **types:** remove `DeepPick` ([7275cb6](https://github.com/flex-development/tutils/commit/7275cb65cefc0de95cb488a3fdf60079b7f1444e))
+* **types:** remove `DeepRequired` ([656f937](https://github.com/flex-development/tutils/commit/656f937d856d640eff7952fb80dea2caec580355))
+* **types:** remove `DocumentPartial` ([1fd729d](https://github.com/flex-development/tutils/commit/1fd729d94d5f6a21140a3bf9d9d0cbc1c83920f4))
+* **types:** remove `DUID` ([61c1550](https://github.com/flex-development/tutils/commit/61c1550ff183d5823764497342ee65a669f78e73))
+* **types:** remove `Intersection` ([bc53cee](https://github.com/flex-development/tutils/commit/bc53cee635cce0cd4e1496e152041453e04a35d7))
+* **types:** remove `Nullish*` ([f082c18](https://github.com/flex-development/tutils/commit/f082c18072e3432319d737e05ccdf191bc7326dd))
+* **types:** remove `NumberString` ([ffbc26f](https://github.com/flex-development/tutils/commit/ffbc26f2f70e7b973ed884fbdc6097d1c399e602))
+* **types:** remove `OmitByType` ([5f45c71](https://github.com/flex-development/tutils/commit/5f45c712051e3ee7c7d021875692900933bb362f))
+* **types:** remove `Or*` ([3312dc0](https://github.com/flex-development/tutils/commit/3312dc041757577fd2607d7b58557280ae576207))
+* **types:** remove `OrDeepPartial` ([854e34c](https://github.com/flex-development/tutils/commit/854e34c2771ab8a2f976984f2aacfa00d696a963))
+* **types:** remove `PickByType` ([fc12dfd](https://github.com/flex-development/tutils/commit/fc12dfda5c1e56c3788d51a76dbb1c8c04cdb95e))
+* **types:** remove `RegexString` ([84236c8](https://github.com/flex-development/tutils/commit/84236c8d897b004b1a766ca730e0ded47e00e4fc))
+* **types:** remove `UID` ([96a2268](https://github.com/flex-development/tutils/commit/96a22682242c3536a67ebb4575c0cfeb62d18fc9))
+* **types:** remove `Union` ([da728ea](https://github.com/flex-development/tutils/commit/da728eaaa218ebf49a022fcbc08df0e7b20c3cf6))
+
 ## [tutils@5.0.1](https://github.com/flex-development/tutils/compare/tutils@5.0.0...tutils@5.0.1) (2022-09-30)
 
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ TypeScript utilities.
 
 This package contains [TypeScript][1] utilities used by the [Flex Development][2] (FLDV) team.
 
-It includes enums, interfaces, types, and type guards.
+It includes enums, types, and type guards.
 
 ## When should I use this?
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flex-development/tutils",
   "description": "TypeScript utilities",
-  "version": "5.0.1",
+  "version": "6.0.0-alpha.1",
   "keywords": [
     "enums",
     "interfaces",


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

- bumped version to `tutils@6.0.0-alpha.1`
- added `CHANGELOG` entry for `tutils@6.0.0-alpha.1`

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

### `yarn test:cov`

```zsh
  RUN  v0.25.3
      Coverage enabled with c8

 ✓ src/guards/__tests__/is-unix-timestamp.spec.ts > unit:guards/isUnixTimestamp > should return false given [null]
 ✓ src/guards/__tests__/is-unix-timestamp.spec.ts > unit:guards/isUnixTimestamp > should return true given [1669256104853]
 ✓ src/guards/__tests__/is-jwt-type.spec.ts > unit:guards/isJwtType > should return false given ["EMAIL"]
 ✓ src/guards/__tests__/is-jwt-type.spec.ts > unit:guards/isJwtType > should return true given ["ACCESS"]
 ✓ src/guards/__tests__/is-jwt-type.spec.ts > unit:guards/isJwtType > should return true given ["REFRESH"]
 ✓ src/guards/__tests__/is-jwt-type.spec.ts > unit:guards/isJwtType > should return true given ["VERIFICATION"]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return false given ["ci"]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return false given ["DEV"]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return true given ["development"]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return true given ["production"]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return true given ["test"]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return false given [[]]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return false given [{}]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return false given [13]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return true given [true]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return true given ["true"]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return true given [false]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return true given ["false"]
 ✓ src/guards/__tests__/is-empty-value.functional.spec.ts > functional:guards/isEmptyValue > should call isEmptyString 1 time and isNIL 0 times given [""]
 ✓ src/guards/__tests__/is-empty-value.functional.spec.ts > functional:guards/isEmptyValue > should call isEmptyString 1 time and isNIL 0 times given ["   "]
 ✓ src/guards/__tests__/is-empty-value.functional.spec.ts > functional:guards/isEmptyValue > should call isEmptyString 1 time and isNIL 1 time given [null]
 ✓ src/guards/__tests__/is-empty-value.functional.spec.ts > functional:guards/isEmptyValue > should call isEmptyString 1 time and isNIL 1 time given [undefined]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given [[]]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given [{}]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given [13]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given [false]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given ["hello world"]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return true given [""]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return true given ["   "]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [[]]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [{}]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [13]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [true]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [false]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given ["string"]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return true given [null]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return true given [undefined]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return false given [[]]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return false given [{}]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return false given [true]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return false given [false]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return true given [13]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return true given ["hello world"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return false given ["cd"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return false given ["PROD"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["ci"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["development"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["staging"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["production"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["test"]

 Test Files  9 passed (9)
      Tests  50 passed (50)
   Start at  21:14:59
   Duration  5.78s (transform 205ms, setup 7.29s, collect 296ms, tests 66ms)

 % Coverage report from c8
-------------------------|---------|----------|---------|---------|-------------------
File                     | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------------|---------|----------|---------|---------|-------------------
All files                |   17.97 |    26.47 |   13.79 |   17.97 |                   
 enums                   |    23.8 |    33.33 |       0 |    23.8 |                   
  app-env.ts             |     100 |      100 |     100 |     100 |                   
  bson-type-alias.ts     |       0 |        0 |       0 |       0 | 1-22              
  bson-type-code.ts      |       0 |        0 |       0 |       0 | 1-22              
  compare-result.ts      |       0 |        0 |       0 |       0 | 1-21              
  http-status.ts         |       0 |        0 |       0 |       0 | 1-77              
  jwt-type.ts            |     100 |      100 |     100 |     100 |                   
  node-env.ts            |     100 |      100 |     100 |     100 |                   
  project-rule.ts        |       0 |        0 |       0 |       0 | 1-16              
  sort-order.ts          |       0 |        0 |       0 |       0 | 1-18              
 guards                  |    87.8 |    93.75 |   88.88 |    87.8 |                   
  is-app-env.ts          |     100 |      100 |     100 |     100 |                   
  is-booleanish.ts       |     100 |      100 |     100 |     100 |                   
  is-empty-string.ts     |     100 |      100 |     100 |     100 |                   
  is-empty-value.ts      |     100 |      100 |     100 |     100 |                   
  is-jwt-type.ts         |     100 |      100 |     100 |     100 |                   
  is-nil.ts              |     100 |      100 |     100 |     100 |                   
  is-node-env.ts         |     100 |      100 |     100 |     100 |                   
  is-number-string.ts    |     100 |      100 |     100 |     100 |                   
  is-unix-timestamp.ts   |       0 |        0 |       0 |       0 | 1-20              
 types                   |       0 |        0 |       0 |       0 |                   
  any.ts                 |       0 |        0 |       0 |       0 | 1-11              
  booleanish.ts          |       0 |        0 |       0 |       0 | 1-11              
  built-in.ts            |       0 |        0 |       0 |       0 | 1-13              
  class.ts               |       0 |        0 |       0 |       0 | 1-20              
  comparison-operator.ts |       0 |        0 |       0 |       0 | 1-11              
  constructor.ts         |       0 |        0 |       0 |       0 | 1-16              
  continuous-value.ts    |       0 |        0 |       0 |       0 | 1-13              
  empty-string.ts        |       0 |        0 |       0 |       0 | 1-11              
  empty-value.ts         |       0 |        0 |       0 |       0 | 1-14              
  fixme.ts               |       0 |        0 |       0 |       0 | 1-11              
  index-signature.ts     |       0 |        0 |       0 |       0 | 1-13              
  is-tuple.ts            |       0 |        0 |       0 |       0 | 1-25              
  join.ts                |       0 |        0 |       0 |       0 | 1-21              
  json-array.ts          |       0 |        0 |       0 |       0 | 1-15              
  json-object.ts         |       0 |        0 |       0 |       0 | 1-24              
  json-primitive.ts      |       0 |        0 |       0 |       0 | 1-14              
  json-value.ts          |       0 |        0 |       0 |       0 | 1-17              
  keys-optional.ts       |       0 |        0 |       0 |       0 | 1-18              
  keys-required.ts       |       0 |        0 |       0 |       0 | 1-18              
  literal-union.ts       |       0 |        0 |       0 |       0 | 1-37              
  nil.ts                 |       0 |        0 |       0 |       0 | 1-11              
  nilable.ts             |       0 |        0 |       0 |       0 | 1-15              
  nullable.ts            |       0 |        0 |       0 |       0 | 1-13              
  number-like.ts         |       0 |        0 |       0 |       0 | 1-13              
  numeric.ts             |       0 |        0 |       0 |       0 | 1-11              
  object-empty.ts        |       0 |        0 |       0 |       0 | 1-11              
  object-plain.ts        |       0 |        0 |       0 |       0 | 1-13              
  object-unknown.ts      |       0 |        0 |       0 |       0 | 1-13              
  one-or-many.ts         |       0 |        0 |       0 |       0 | 1-13              
  opaque.ts              |       0 |        0 |       0 |       0 | 1-24              
  overwrite.ts           |       0 |        0 |       0 |       0 | 1-18              
  path-n.ts              |       0 |        0 |       0 |       0 | 1-25              
  path-nt.ts             |       0 |        0 |       0 |       0 | 1-18              
  path-value.ts          |       0 |        0 |       0 |       0 | 1-30              
  path.ts                |       0 |        0 |       0 |       0 | 1-22              
  predicate.ts           |       0 |        0 |       0 |       0 | 1-19              
  primitive.ts           |       0 |        0 |       0 |       0 | 1-15              
  promisable.ts          |       0 |        0 |       0 |       0 | 1-15              
  semantic-version.ts    |       0 |        0 |       0 |       0 | 1-19              
  simplify.ts            |       0 |        0 |       0 |       0 | 1-17              
  split.ts               |       0 |        0 |       0 |       0 | 1-20              
  string-like.ts         |       0 |        0 |       0 |       0 | 1-11              
  timestamp-unix.ts      |       0 |        0 |       0 |       0 | 1-13              
-------------------------|---------|----------|---------|---------|-------------------
```

### `yarn build`

```zsh
ℹ Building @flex-development/tutils                                                                 21:15:19
✔ Build succeeded for @flex-development/tutils                                                      21:15:23
  dist (total size: 51.1 kB)                                                                        21:15:23
  └─ dist/index.mjs.map (116 B)
  └─ dist/index.mjs (111 B)
  └─ dist/index.d.mts (131 B)
  └─ dist/enums/app-env.mjs.map (274 B)
  └─ dist/enums/app-env.mjs (339 B)
  └─ dist/enums/app-env.d.mts (283 B)
  └─ dist/enums/bson-type-alias.mjs.map (312 B)
  └─ dist/enums/bson-type-alias.mjs (468 B)
  └─ dist/enums/bson-type-alias.d.mts (432 B)
  └─ dist/enums/bson-type-code.mjs.map (345 B)
  └─ dist/enums/bson-type-code.mjs (572 B)
  └─ dist/enums/bson-type-code.d.mts (390 B)
  └─ dist/enums/compare-result.mjs.map (267 B)
  └─ dist/enums/compare-result.mjs (439 B)
  └─ dist/enums/compare-result.d.mts (445 B)
  └─ dist/enums/http-status.mjs.map (1.94 kB)
  └─ dist/enums/http-status.mjs (4.65 kB)
  └─ dist/enums/http-status.d.mts (1.89 kB)
  └─ dist/enums/index.mjs.map (328 B)
  └─ dist/enums/index.mjs (757 B)
  └─ dist/enums/index.d.mts (554 B)
  └─ dist/enums/jwt-type.mjs.map (235 B)
  └─ dist/enums/jwt-type.mjs (310 B)
  └─ dist/enums/jwt-type.d.mts (291 B)
  └─ dist/enums/node-env.mjs.map (234 B)
  └─ dist/enums/node-env.mjs (296 B)
  └─ dist/enums/node-env.d.mts (244 B)
  └─ dist/enums/project-rule.mjs.map (234 B)
  └─ dist/enums/project-rule.mjs (331 B)
  └─ dist/enums/project-rule.d.mts (253 B)
  └─ dist/enums/sort-order.mjs.map (230 B)
  └─ dist/enums/sort-order.mjs (330 B)
  └─ dist/enums/sort-order.d.mts (333 B)
  └─ dist/guards/index.mjs.map (304 B)
  └─ dist/guards/index.mjs (700 B)
  └─ dist/guards/index.d.mts (530 B)
  └─ dist/guards/is-app-env.mjs.map (206 B)
  └─ dist/guards/is-app-env.mjs (241 B)
  └─ dist/guards/is-app-env.d.mts (357 B)
  └─ dist/guards/is-booleanish.mjs.map (193 B)
  └─ dist/guards/is-booleanish.mjs (247 B)
  └─ dist/guards/is-booleanish.d.mts (397 B)
  └─ dist/guards/is-empty-string.mjs.map (202 B)
  └─ dist/guards/is-empty-string.mjs (243 B)
  └─ dist/guards/is-empty-string.d.mts (324 B)
  └─ dist/guards/is-empty-value.mjs.map (223 B)
  └─ dist/guards/is-empty-value.mjs (296 B)
  └─ dist/guards/is-empty-value.d.mts (404 B)
  └─ dist/guards/is-jwt-type.mjs.map (208 B)
  └─ dist/guards/is-jwt-type.mjs (249 B)
  └─ dist/guards/is-jwt-type.d.mts (357 B)
  └─ dist/guards/is-nil.mjs.map (171 B)
  └─ dist/guards/is-nil.mjs (179 B)
  └─ dist/guards/is-nil.d.mts (336 B)
  └─ dist/guards/is-node-env.mjs.map (223 B)
  └─ dist/guards/is-node-env.mjs (272 B)
  └─ dist/guards/is-node-env.d.mts (386 B)
  └─ dist/guards/is-number-string.mjs.map (193 B)
  └─ dist/guards/is-number-string.mjs (247 B)
  └─ dist/guards/is-number-string.d.mts (355 B)
  └─ dist/guards/is-unix-timestamp.mjs.map (214 B)
  └─ dist/guards/is-unix-timestamp.mjs (268 B)
  └─ dist/guards/is-unix-timestamp.d.mts (410 B)
  └─ dist/types/any.mjs.map (69 B)
  └─ dist/types/any.mjs (33 B)
  └─ dist/types/any.d.mts (156 B)
  └─ dist/types/booleanish.mjs.map (69 B)
  └─ dist/types/booleanish.mjs (40 B)
  └─ dist/types/booleanish.d.mts (236 B)
  └─ dist/types/built-in.mjs.map (69 B)
  └─ dist/types/built-in.mjs (38 B)
  └─ dist/types/built-in.d.mts (243 B)
  └─ dist/types/class.mjs.map (69 B)
  └─ dist/types/class.mjs (35 B)
  └─ dist/types/class.d.mts (444 B)
  └─ dist/types/comparison-operator.mjs.map (69 B)
  └─ dist/types/comparison-operator.mjs (49 B)
  └─ dist/types/comparison-operator.d.mts (264 B)
  └─ dist/types/constructor.mjs.map (69 B)
  └─ dist/types/constructor.mjs (41 B)
  └─ dist/types/constructor.d.mts (411 B)
  └─ dist/types/continuous-value.mjs.map (69 B)
  └─ dist/types/continuous-value.mjs (46 B)
  └─ dist/types/continuous-value.d.mts (275 B)
  └─ dist/types/empty-string.mjs.map (69 B)
  └─ dist/types/empty-string.mjs (42 B)
  └─ dist/types/empty-string.d.mts (193 B)
  └─ dist/types/empty-value.mjs.map (69 B)
  └─ dist/types/empty-value.mjs (41 B)
  └─ dist/types/empty-value.d.mts (304 B)
  └─ dist/types/fixme.mjs.map (69 B)
  └─ dist/types/fixme.mjs (35 B)
  └─ dist/types/fixme.d.mts (202 B)
  └─ dist/types/index-signature.mjs.map (69 B)
  └─ dist/types/index-signature.mjs (45 B)
  └─ dist/types/index-signature.d.mts (300 B)
  └─ dist/types/index.mjs.map (69 B)
  └─ dist/types/index.mjs (35 B)
  └─ dist/types/index.d.mts (2.51 kB)
  └─ dist/types/is-tuple.mjs.map (69 B)
  └─ dist/types/is-tuple.mjs (38 B)
  └─ dist/types/is-tuple.d.mts (507 B)
  └─ dist/types/join.mjs.map (69 B)
  └─ dist/types/join.mjs (34 B)
  └─ dist/types/join.d.mts (498 B)
  └─ dist/types/json-array.mjs.map (69 B)
  └─ dist/types/json-array.mjs (40 B)
  └─ dist/types/json-array.d.mts (308 B)
  └─ dist/types/json-object.mjs.map (69 B)
  └─ dist/types/json-object.mjs (41 B)
  └─ dist/types/json-object.d.mts (752 B)
  └─ dist/types/json-primitive.mjs.map (69 B)
  └─ dist/types/json-primitive.mjs (44 B)
  └─ dist/types/json-primitive.d.mts (362 B)
  └─ dist/types/json-value.mjs.map (69 B)
  └─ dist/types/json-value.mjs (40 B)
  └─ dist/types/json-value.d.mts (397 B)
  └─ dist/types/keys-optional.mjs.map (69 B)
  └─ dist/types/keys-optional.mjs (43 B)
  └─ dist/types/keys-optional.d.mts (390 B)
  └─ dist/types/keys-required.mjs.map (69 B)
  └─ dist/types/keys-required.mjs (43 B)
  └─ dist/types/keys-required.d.mts (390 B)
  └─ dist/types/literal-union.mjs.map (69 B)
  └─ dist/types/literal-union.mjs (43 B)
  └─ dist/types/literal-union.d.mts (1.3 kB)
  └─ dist/types/nil.mjs.map (69 B)
  └─ dist/types/nil.mjs (33 B)
  └─ dist/types/nil.d.mts (189 B)
  └─ dist/types/nilable.mjs.map (69 B)
  └─ dist/types/nilable.mjs (37 B)
  └─ dist/types/nilable.d.mts (257 B)
  └─ dist/types/nullable.mjs.map (69 B)
  └─ dist/types/nullable.mjs (38 B)
  └─ dist/types/nullable.d.mts (248 B)
  └─ dist/types/number-like.mjs.map (69 B)
  └─ dist/types/number-like.mjs (41 B)
  └─ dist/types/number-like.d.mts (255 B)
  └─ dist/types/numeric.mjs.map (69 B)
  └─ dist/types/numeric.mjs (37 B)
  └─ dist/types/numeric.d.mts (188 B)
  └─ dist/types/object-empty.mjs.map (69 B)
  └─ dist/types/object-empty.mjs (42 B)
  └─ dist/types/object-empty.d.mts (213 B)
  └─ dist/types/object-plain.mjs.map (69 B)
  └─ dist/types/object-plain.mjs (42 B)
  └─ dist/types/object-plain.d.mts (296 B)
  └─ dist/types/object-unknown.mjs.map (69 B)
  └─ dist/types/object-unknown.mjs (44 B)
  └─ dist/types/object-unknown.d.mts (289 B)
  └─ dist/types/one-or-many.mjs.map (69 B)
  └─ dist/types/one-or-many.mjs (41 B)
  └─ dist/types/one-or-many.d.mts (245 B)
  └─ dist/types/opaque.mjs.map (69 B)
  └─ dist/types/opaque.mjs (36 B)
  └─ dist/types/opaque.d.mts (584 B)
  └─ dist/types/overwrite.mjs.map (69 B)
  └─ dist/types/overwrite.mjs (39 B)
  └─ dist/types/overwrite.d.mts (453 B)
  └─ dist/types/path-n.mjs.map (69 B)
  └─ dist/types/path-n.mjs (36 B)
  └─ dist/types/path-n.d.mts (683 B)
  └─ dist/types/path-nt.mjs.map (69 B)
  └─ dist/types/path-nt.mjs (37 B)
  └─ dist/types/path-nt.d.mts (468 B)
  └─ dist/types/path-value.mjs.map (69 B)
  └─ dist/types/path-value.mjs (40 B)
  └─ dist/types/path-value.d.mts (686 B)
  └─ dist/types/path.mjs.map (69 B)
  └─ dist/types/path.mjs (34 B)
  └─ dist/types/path.d.mts (532 B)
  └─ dist/types/predicate.mjs.map (69 B)
  └─ dist/types/predicate.mjs (39 B)
  └─ dist/types/predicate.d.mts (578 B)
  └─ dist/types/primitive.mjs.map (69 B)
  └─ dist/types/primitive.mjs (39 B)
  └─ dist/types/primitive.d.mts (351 B)
  └─ dist/types/promisable.mjs.map (69 B)
  └─ dist/types/promisable.mjs (40 B)
  └─ dist/types/promisable.d.mts (321 B)
  └─ dist/types/semantic-version.mjs.map (69 B)
  └─ dist/types/semantic-version.mjs (46 B)
  └─ dist/types/semantic-version.d.mts (465 B)
  └─ dist/types/simplify.mjs.map (69 B)
  └─ dist/types/simplify.mjs (38 B)
  └─ dist/types/simplify.d.mts (382 B)
  └─ dist/types/split.mjs.map (69 B)
  └─ dist/types/split.mjs (35 B)
  └─ dist/types/split.d.mts (423 B)
  └─ dist/types/string-like.mjs.map (69 B)
  └─ dist/types/string-like.mjs (41 B)
  └─ dist/types/string-like.d.mts (221 B)
  └─ dist/types/timestamp-unix.mjs.map (69 B)
  └─ dist/types/timestamp-unix.mjs (44 B)
  └─ dist/types/timestamp-unix.d.mts (271 B)
  dist (total size: 108 kB)                                                                         21:15:23
  └─ dist/index.cjs.map (161 B)
  └─ dist/index.cjs (1.09 kB)
  └─ dist/index.d.cts (131 B)
  └─ dist/enums/app-env.cjs.map (316 B)
  └─ dist/enums/app-env.cjs (1.22 kB)
  └─ dist/enums/app-env.d.cts (283 B)
  └─ dist/enums/bson-type-alias.cjs.map (354 B)
  └─ dist/enums/bson-type-alias.cjs (1.38 kB)
  └─ dist/enums/bson-type-alias.d.cts (432 B)
  └─ dist/enums/bson-type-code.cjs.map (387 B)
  └─ dist/enums/bson-type-code.cjs (1.48 kB)
  └─ dist/enums/bson-type-code.d.cts (390 B)
  └─ dist/enums/compare-result.cjs.map (309 B)
  └─ dist/enums/compare-result.cjs (1.34 kB)
  └─ dist/enums/compare-result.d.cts (445 B)
  └─ dist/enums/http-status.cjs.map (1.99 kB)
  └─ dist/enums/http-status.cjs (5.55 kB)
  └─ dist/enums/http-status.d.cts (1.89 kB)
  └─ dist/enums/index.cjs.map (299 B)
  └─ dist/enums/index.cjs (2.2 kB)
  └─ dist/enums/index.d.cts (554 B)
  └─ dist/enums/jwt-type.cjs.map (277 B)
  └─ dist/enums/jwt-type.cjs (1.2 kB)
  └─ dist/enums/jwt-type.d.cts (291 B)
  └─ dist/enums/node-env.cjs.map (276 B)
  └─ dist/enums/node-env.cjs (1.18 kB)
  └─ dist/enums/node-env.d.cts (244 B)
  └─ dist/enums/project-rule.cjs.map (276 B)
  └─ dist/enums/project-rule.cjs (1.23 kB)
  └─ dist/enums/project-rule.d.cts (253 B)
  └─ dist/enums/sort-order.cjs.map (272 B)
  └─ dist/enums/sort-order.cjs (1.22 kB)
  └─ dist/enums/sort-order.d.cts (333 B)
  └─ dist/guards/index.cjs.map (282 B)
  └─ dist/guards/index.cjs (2.15 kB)
  └─ dist/guards/index.d.cts (530 B)
  └─ dist/guards/is-app-env.cjs.map (265 B)
  └─ dist/guards/is-app-env.cjs (1.48 kB)
  └─ dist/guards/is-app-env.d.cts (357 B)
  └─ dist/guards/is-booleanish.cjs.map (235 B)
  └─ dist/guards/is-booleanish.cjs (1.15 kB)
  └─ dist/guards/is-booleanish.d.cts (397 B)
  └─ dist/guards/is-empty-string.cjs.map (244 B)
  └─ dist/guards/is-empty-string.cjs (1.15 kB)
  └─ dist/guards/is-empty-string.d.cts (324 B)
  └─ dist/guards/is-empty-value.cjs.map (300 B)
  └─ dist/guards/is-empty-value.cjs (1.59 kB)
  └─ dist/guards/is-empty-value.d.cts (404 B)
  └─ dist/guards/is-jwt-type.cjs.map (269 B)
  └─ dist/guards/is-jwt-type.cjs (1.49 kB)
  └─ dist/guards/is-jwt-type.d.cts (357 B)
  └─ dist/guards/is-nil.cjs.map (213 B)
  └─ dist/guards/is-nil.cjs (1.06 kB)
  └─ dist/guards/is-nil.d.cts (336 B)
  └─ dist/guards/is-node-env.cjs.map (284 B)
  └─ dist/guards/is-node-env.cjs (1.51 kB)
  └─ dist/guards/is-node-env.d.cts (386 B)
  └─ dist/guards/is-number-string.cjs.map (235 B)
  └─ dist/guards/is-number-string.cjs (1.16 kB)
  └─ dist/guards/is-number-string.d.cts (355 B)
  └─ dist/guards/is-unix-timestamp.cjs.map (256 B)
  └─ dist/guards/is-unix-timestamp.cjs (1.18 kB)
  └─ dist/guards/is-unix-timestamp.d.cts (410 B)
  └─ dist/types/any.cjs.map (116 B)
  └─ dist/types/any.cjs (756 B)
  └─ dist/types/any.d.cts (156 B)
  └─ dist/types/booleanish.cjs.map (123 B)
  └─ dist/types/booleanish.cjs (777 B)
  └─ dist/types/booleanish.d.cts (236 B)
  └─ dist/types/built-in.cjs.map (121 B)
  └─ dist/types/built-in.cjs (771 B)
  └─ dist/types/built-in.d.cts (243 B)
  └─ dist/types/class.cjs.map (118 B)
  └─ dist/types/class.cjs (762 B)
  └─ dist/types/class.d.cts (444 B)
  └─ dist/types/comparison-operator.cjs.map (132 B)
  └─ dist/types/comparison-operator.cjs (804 B)
  └─ dist/types/comparison-operator.d.cts (264 B)
  └─ dist/types/constructor.cjs.map (124 B)
  └─ dist/types/constructor.cjs (780 B)
  └─ dist/types/constructor.d.cts (411 B)
  └─ dist/types/continuous-value.cjs.map (129 B)
  └─ dist/types/continuous-value.cjs (795 B)
  └─ dist/types/continuous-value.d.cts (275 B)
  └─ dist/types/empty-string.cjs.map (125 B)
  └─ dist/types/empty-string.cjs (783 B)
  └─ dist/types/empty-string.d.cts (193 B)
  └─ dist/types/empty-value.cjs.map (124 B)
  └─ dist/types/empty-value.cjs (780 B)
  └─ dist/types/empty-value.d.cts (304 B)
  └─ dist/types/fixme.cjs.map (118 B)
  └─ dist/types/fixme.cjs (762 B)
  └─ dist/types/fixme.d.cts (202 B)
  └─ dist/types/index-signature.cjs.map (128 B)
  └─ dist/types/index-signature.cjs (792 B)
  └─ dist/types/index-signature.d.cts (300 B)
  └─ dist/types/index.cjs.map (118 B)
  └─ dist/types/index.cjs (762 B)
  └─ dist/types/index.d.cts (2.51 kB)
  └─ dist/types/is-tuple.cjs.map (121 B)
  └─ dist/types/is-tuple.cjs (771 B)
  └─ dist/types/is-tuple.d.cts (507 B)
  └─ dist/types/join.cjs.map (117 B)
  └─ dist/types/join.cjs (759 B)
  └─ dist/types/join.d.cts (498 B)
  └─ dist/types/json-array.cjs.map (123 B)
  └─ dist/types/json-array.cjs (777 B)
  └─ dist/types/json-array.d.cts (308 B)
  └─ dist/types/json-object.cjs.map (124 B)
  └─ dist/types/json-object.cjs (780 B)
  └─ dist/types/json-object.d.cts (752 B)
  └─ dist/types/json-primitive.cjs.map (127 B)
  └─ dist/types/json-primitive.cjs (789 B)
  └─ dist/types/json-primitive.d.cts (362 B)
  └─ dist/types/json-value.cjs.map (123 B)
  └─ dist/types/json-value.cjs (777 B)
  └─ dist/types/json-value.d.cts (397 B)
  └─ dist/types/keys-optional.cjs.map (126 B)
  └─ dist/types/keys-optional.cjs (786 B)
  └─ dist/types/keys-optional.d.cts (390 B)
  └─ dist/types/keys-required.cjs.map (126 B)
  └─ dist/types/keys-required.cjs (786 B)
  └─ dist/types/keys-required.d.cts (390 B)
  └─ dist/types/literal-union.cjs.map (126 B)
  └─ dist/types/literal-union.cjs (786 B)
  └─ dist/types/literal-union.d.cts (1.3 kB)
  └─ dist/types/nil.cjs.map (116 B)
  └─ dist/types/nil.cjs (756 B)
  └─ dist/types/nil.d.cts (189 B)
  └─ dist/types/nilable.cjs.map (120 B)
  └─ dist/types/nilable.cjs (768 B)
  └─ dist/types/nilable.d.cts (257 B)
  └─ dist/types/nullable.cjs.map (121 B)
  └─ dist/types/nullable.cjs (771 B)
  └─ dist/types/nullable.d.cts (248 B)
  └─ dist/types/number-like.cjs.map (124 B)
  └─ dist/types/number-like.cjs (780 B)
  └─ dist/types/number-like.d.cts (255 B)
  └─ dist/types/numeric.cjs.map (120 B)
  └─ dist/types/numeric.cjs (768 B)
  └─ dist/types/numeric.d.cts (188 B)
  └─ dist/types/object-empty.cjs.map (125 B)
  └─ dist/types/object-empty.cjs (783 B)
  └─ dist/types/object-empty.d.cts (213 B)
  └─ dist/types/object-plain.cjs.map (125 B)
  └─ dist/types/object-plain.cjs (783 B)
  └─ dist/types/object-plain.d.cts (296 B)
  └─ dist/types/object-unknown.cjs.map (127 B)
  └─ dist/types/object-unknown.cjs (789 B)
  └─ dist/types/object-unknown.d.cts (289 B)
  └─ dist/types/one-or-many.cjs.map (124 B)
  └─ dist/types/one-or-many.cjs (780 B)
  └─ dist/types/one-or-many.d.cts (245 B)
  └─ dist/types/opaque.cjs.map (119 B)
  └─ dist/types/opaque.cjs (765 B)
  └─ dist/types/opaque.d.cts (584 B)
  └─ dist/types/overwrite.cjs.map (122 B)
  └─ dist/types/overwrite.cjs (774 B)
  └─ dist/types/overwrite.d.cts (453 B)
  └─ dist/types/path-n.cjs.map (119 B)
  └─ dist/types/path-n.cjs (765 B)
  └─ dist/types/path-n.d.cts (683 B)
  └─ dist/types/path-nt.cjs.map (120 B)
  └─ dist/types/path-nt.cjs (768 B)
  └─ dist/types/path-nt.d.cts (468 B)
  └─ dist/types/path-value.cjs.map (123 B)
  └─ dist/types/path-value.cjs (777 B)
  └─ dist/types/path-value.d.cts (686 B)
  └─ dist/types/path.cjs.map (117 B)
  └─ dist/types/path.cjs (759 B)
  └─ dist/types/path.d.cts (532 B)
  └─ dist/types/predicate.cjs.map (122 B)
  └─ dist/types/predicate.cjs (774 B)
  └─ dist/types/predicate.d.cts (578 B)
  └─ dist/types/primitive.cjs.map (122 B)
  └─ dist/types/primitive.cjs (774 B)
  └─ dist/types/primitive.d.cts (351 B)
  └─ dist/types/promisable.cjs.map (123 B)
  └─ dist/types/promisable.cjs (777 B)
  └─ dist/types/promisable.d.cts (321 B)
  └─ dist/types/semantic-version.cjs.map (129 B)
  └─ dist/types/semantic-version.cjs (795 B)
  └─ dist/types/semantic-version.d.cts (465 B)
  └─ dist/types/simplify.cjs.map (121 B)
  └─ dist/types/simplify.cjs (771 B)
  └─ dist/types/simplify.d.cts (382 B)
  └─ dist/types/split.cjs.map (118 B)
  └─ dist/types/split.cjs (762 B)
  └─ dist/types/split.d.cts (423 B)
  └─ dist/types/string-like.cjs.map (124 B)
  └─ dist/types/string-like.cjs (780 B)
  └─ dist/types/string-like.d.cts (221 B)
  └─ dist/types/timestamp-unix.cjs.map (127 B)
  └─ dist/types/timestamp-unix.cjs (789 B)
  └─ dist/types/timestamp-unix.d.cts (271 B)
Σ Total build size: 159 kB                                                                          21:15:23
```

## Additional context

<!-- Add any other information (docs, files, issue references, etc) about the pull request here. -->

N/A

## Linked issues

<!-- closes #[issue number], fixes #[issue number] -->

N/A

## Submission checklist

- [x] self-review performed
- [x] tests added and/or updated
- [x] documentation added or updated
- [x] new, **tolerable** vulnerabilities and/or warnings documented, if any
- [x] [pr naming conventions][1]

[1]: https://github.com/flex-development/tutils/blob/main/CONTRIBUTING.md#pull-request-titles
