### PR TITLE
release: tutils@6.0.0-alpha.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## [tutils@6.0.0-alpha.5](https://github.com/flex-development/tutils/compare/tutils@6.0.0-alpha.4...tutils@6.0.0-alpha.5) (2022-12-02)
+
+
+### ⚠ BREAKING CHANGES
+
+* **types:** make `JsonObject` work as expected with `exactOptionalPropertyTypes`
+* **types:** `JSON*` -> `Json*`
+
+### :sparkles: Features
+
+* **types:** `Jsonifiable`, `JsonifiableArray`, `JsonifiableObject` ([d3b4e43](https://github.com/flex-development/tutils/commit/d3b4e43b56487157fd143d5de9aed9c9eea834bb))
+
+
+### :bug: Fixes
+
+* **types:** make `JsonObject` work as expected with `exactOptionalPropertyTypes` ([64e5daa](https://github.com/flex-development/tutils/commit/64e5daaf394b9c10e3d962a4f8d12958bad51b2f))
+
+
+### :house_with_garden: Housekeeping
+
+* **ts:** enforce `exactOptionalPropertyTypes` ([3d562a7](https://github.com/flex-development/tutils/commit/3d562a730794ce79a68df18565c901516d6f522a))
+
+
+### :zap: Refactors
+
+* **types:** `JSON*` -> `Json*` ([bd3193f](https://github.com/flex-development/tutils/commit/bd3193f109766d1d1081bf17afe0802806d20579))
+
+
+### :rewind: Reverts
+
+* **types:** aea1f33ded81c0602ea10263980676773d190e33 ([2dd3c8f](https://github.com/flex-development/tutils/commit/2dd3c8fda32d88cce2c73e1b655057fd016bf14a))
+
 ## [tutils@6.0.0-alpha.4](https://github.com/flex-development/tutils/compare/tutils@6.0.0-alpha.3...tutils@6.0.0-alpha.4) (2022-12-01)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flex-development/tutils",
   "description": "TypeScript utilities",
-  "version": "6.0.0-alpha.4",
+  "version": "6.0.0-alpha.5",
   "keywords": [
     "enums",
     "interfaces",


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

- bumped version to `6.0.0-alpha.5`
- added `CHANGELOG` entry for `tutils@6.0.0-alpha.5`

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

### `yarn test:cov`

```zsh
  RUN  v0.25.3
      Coverage enabled with c8

 ✓ src/guards/__tests__/is-unix-timestamp.spec.ts > unit:guards/isUnixTimestamp > should return false given [null]
 ✓ src/guards/__tests__/is-unix-timestamp.spec.ts > unit:guards/isUnixTimestamp > should return true given [1670018917635]
 ✓ src/guards/__tests__/is-empty-value.functional.spec.ts > functional:guards/isEmptyValue > should call isEmptyString 1 time and isNIL 0 times given [""]
 ✓ src/guards/__tests__/is-empty-value.functional.spec.ts > functional:guards/isEmptyValue > should call isEmptyString 1 time and isNIL 0 times given ["   "]
 ✓ src/guards/__tests__/is-empty-value.functional.spec.ts > functional:guards/isEmptyValue > should call isEmptyString 1 time and isNIL 1 time given [null]
 ✓ src/guards/__tests__/is-empty-value.functional.spec.ts > functional:guards/isEmptyValue > should call isEmptyString 1 time and isNIL 1 time given [undefined]
 ✓ src/guards/__tests__/is-jwt-type.spec.ts > unit:guards/isJwtType > should return false given ["EMAIL"]
 ✓ src/guards/__tests__/is-jwt-type.spec.ts > unit:guards/isJwtType > should return true given ["ACCESS"]
 ✓ src/guards/__tests__/is-jwt-type.spec.ts > unit:guards/isJwtType > should return true given ["REFRESH"]
 ✓ src/guards/__tests__/is-jwt-type.spec.ts > unit:guards/isJwtType > should return true given ["VERIFICATION"]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [[]]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [{}]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [13]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [true]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [false]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given ["string"]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return true given [null]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return true given [undefined]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given [[]]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given [{}]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given [13]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given [false]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given ["hello world"]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return true given [""]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return true given ["   "]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return false given ["ci"]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return false given ["DEV"]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return true given ["development"]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return true given ["production"]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return true given ["test"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return false given ["cd"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return false given ["PROD"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["ci"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["development"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["staging"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["production"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["test"]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return false given [[]]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return false given [{}]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return false given [13]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return true given [true]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return true given ["true"]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return true given [false]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return true given ["false"]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return false given [[]]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return false given [{}]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return false given [true]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return false given [false]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return true given [13]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return true given ["hello world"]

 Test Files  9 passed (9)
      Tests  50 passed (50)
   Start at  17:08:35
   Duration  2.95s (transform 193ms, setup 5.44s, collect 172ms, tests 205ms)

 % Coverage report from c8
-------------------------|---------|----------|---------|---------|-------------------
File                     | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------------|---------|----------|---------|---------|-------------------
All files                |   16.56 |    24.32 |    12.5 |   16.56 |                   
 enums                   |    23.8 |    33.33 |       0 |    23.8 |                   
  app-env.ts             |     100 |      100 |     100 |     100 |                   
  bson-type-alias.ts     |       0 |        0 |       0 |       0 | 1-22              
  bson-type-code.ts      |       0 |        0 |       0 |       0 | 1-22              
  compare-result.ts      |       0 |        0 |       0 |       0 | 1-21              
  http-status.ts         |       0 |        0 |       0 |       0 | 1-77              
  jwt-type.ts            |     100 |      100 |     100 |     100 |                   
  node-env.ts            |     100 |      100 |     100 |     100 |                   
  project-rule.ts        |       0 |        0 |       0 |       0 | 1-16              
  sort-order.ts          |       0 |        0 |       0 |       0 | 1-18              
 guards                  |    87.8 |    93.75 |   88.88 |    87.8 |                   
  is-app-env.ts          |     100 |      100 |     100 |     100 |                   
  is-booleanish.ts       |     100 |      100 |     100 |     100 |                   
  is-empty-string.ts     |     100 |      100 |     100 |     100 |                   
  is-empty-value.ts      |     100 |      100 |     100 |     100 |                   
  is-jwt-type.ts         |     100 |      100 |     100 |     100 |                   
  is-nil.ts              |     100 |      100 |     100 |     100 |                   
  is-node-env.ts         |     100 |      100 |     100 |     100 |                   
  is-number-string.ts    |     100 |      100 |     100 |     100 |                   
  is-unix-timestamp.ts   |       0 |        0 |       0 |       0 | 1-20              
 interfaces              |       0 |        0 |       0 |       0 |                   
  map-like.ts            |       0 |        0 |       0 |       0 | 1-15              
 types                   |       0 |        0 |       0 |       0 |                   
  any.ts                 |       0 |        0 |       0 |       0 | 1-11              
  booleanish.ts          |       0 |        0 |       0 |       0 | 1-11              
  built-in.ts            |       0 |        0 |       0 |       0 | 1-13              
  class.ts               |       0 |        0 |       0 |       0 | 1-20              
  comparison-operator.ts |       0 |        0 |       0 |       0 | 1-11              
  constructor.ts         |       0 |        0 |       0 |       0 | 1-16              
  continuous-value.ts    |       0 |        0 |       0 |       0 | 1-13              
  empty-string.ts        |       0 |        0 |       0 |       0 | 1-11              
  empty-value.ts         |       0 |        0 |       0 |       0 | 1-14              
  fixme.ts               |       0 |        0 |       0 |       0 | 1-11              
  index-signature.ts     |       0 |        0 |       0 |       0 | 1-13              
  is-tuple.ts            |       0 |        0 |       0 |       0 | 1-25              
  join.ts                |       0 |        0 |       0 |       0 | 1-21              
  json-array.ts          |       0 |        0 |       0 |       0 | 1-15              
  json-object.ts         |       0 |        0 |       0 |       0 | 1-24              
  json-primitive.ts      |       0 |        0 |       0 |       0 | 1-14              
  json-value.ts          |       0 |        0 |       0 |       0 | 1-17              
  jsonifiable-array.ts   |       0 |        0 |       0 |       0 | 1-15              
  jsonifiable-object.ts  |       0 |        0 |       0 |       0 | 1-17              
  jsonifiable.ts         |       0 |        0 |       0 |       0 | 1-17              
  keys-optional.ts       |       0 |        0 |       0 |       0 | 1-18              
  keys-required.ts       |       0 |        0 |       0 |       0 | 1-18              
  literal-union.ts       |       0 |        0 |       0 |       0 | 1-37              
  nil.ts                 |       0 |        0 |       0 |       0 | 1-11              
  nilable.ts             |       0 |        0 |       0 |       0 | 1-15              
  nullable.ts            |       0 |        0 |       0 |       0 | 1-13              
  number-like.ts         |       0 |        0 |       0 |       0 | 1-13              
  numeric.ts             |       0 |        0 |       0 |       0 | 1-11              
  object-empty.ts        |       0 |        0 |       0 |       0 | 1-11              
  object-plain.ts        |       0 |        0 |       0 |       0 | 1-13              
  object-unknown.ts      |       0 |        0 |       0 |       0 | 1-13              
  one-or-many.ts         |       0 |        0 |       0 |       0 | 1-13              
  opaque.ts              |       0 |        0 |       0 |       0 | 1-24              
  or-lowercase.ts        |       0 |        0 |       0 |       0 | 1-15              
  or-uppercase.ts        |       0 |        0 |       0 |       0 | 1-15              
  overwrite.ts           |       0 |        0 |       0 |       0 | 1-18              
  path-n.ts              |       0 |        0 |       0 |       0 | 1-25              
  path-nt.ts             |       0 |        0 |       0 |       0 | 1-18              
  path-value.ts          |       0 |        0 |       0 |       0 | 1-30              
  path.ts                |       0 |        0 |       0 |       0 | 1-22              
  predicate.ts           |       0 |        0 |       0 |       0 | 1-19              
  primitive.ts           |       0 |        0 |       0 |       0 | 1-15              
  promisable.ts          |       0 |        0 |       0 |       0 | 1-15              
  semantic-version.ts    |       0 |        0 |       0 |       0 | 1-19              
  simplify.ts            |       0 |        0 |       0 |       0 | 1-17              
  split.ts               |       0 |        0 |       0 |       0 | 1-20              
  string-like.ts         |       0 |        0 |       0 |       0 | 1-11              
  timestamp-unix.ts      |       0 |        0 |       0 |       0 | 1-13              
-------------------------|---------|----------|---------|---------|-------------------
```

### `yarn build`

```zsh
ℹ Building @flex-development/tutils                                                                 17:13:10
✔ Build succeeded for @flex-development/tutils                                                      17:13:15
  dist (total size: 54.7 kB)                                                                        17:13:15
  └─ dist/index.mjs.map (126 B)
  └─ dist/index.mjs (141 B)
  └─ dist/index.d.mts (161 B)
  └─ dist/enums/app-env.mjs.map (274 B)
  └─ dist/enums/app-env.mjs (339 B)
  └─ dist/enums/app-env.d.mts (283 B)
  └─ dist/enums/bson-type-alias.mjs.map (312 B)
  └─ dist/enums/bson-type-alias.mjs (468 B)
  └─ dist/enums/bson-type-alias.d.mts (432 B)
  └─ dist/enums/bson-type-code.mjs.map (345 B)
  └─ dist/enums/bson-type-code.mjs (572 B)
  └─ dist/enums/bson-type-code.d.mts (390 B)
  └─ dist/enums/compare-result.mjs.map (267 B)
  └─ dist/enums/compare-result.mjs (439 B)
  └─ dist/enums/compare-result.d.mts (445 B)
  └─ dist/enums/http-status.mjs.map (1.94 kB)
  └─ dist/enums/http-status.mjs (4.65 kB)
  └─ dist/enums/http-status.d.mts (1.89 kB)
  └─ dist/enums/index.mjs.map (328 B)
  └─ dist/enums/index.mjs (757 B)
  └─ dist/enums/index.d.mts (554 B)
  └─ dist/enums/jwt-type.mjs.map (235 B)
  └─ dist/enums/jwt-type.mjs (310 B)
  └─ dist/enums/jwt-type.d.mts (291 B)
  └─ dist/enums/node-env.mjs.map (234 B)
  └─ dist/enums/node-env.mjs (296 B)
  └─ dist/enums/node-env.d.mts (244 B)
  └─ dist/enums/project-rule.mjs.map (234 B)
  └─ dist/enums/project-rule.mjs (331 B)
  └─ dist/enums/project-rule.d.mts (253 B)
  └─ dist/enums/sort-order.mjs.map (230 B)
  └─ dist/enums/sort-order.mjs (330 B)
  └─ dist/enums/sort-order.d.mts (333 B)
  └─ dist/guards/index.mjs.map (304 B)
  └─ dist/guards/index.mjs (700 B)
  └─ dist/guards/index.d.mts (530 B)
  └─ dist/guards/is-app-env.mjs.map (206 B)
  └─ dist/guards/is-app-env.mjs (241 B)
  └─ dist/guards/is-app-env.d.mts (357 B)
  └─ dist/guards/is-booleanish.mjs.map (193 B)
  └─ dist/guards/is-booleanish.mjs (247 B)
  └─ dist/guards/is-booleanish.d.mts (397 B)
  └─ dist/guards/is-empty-string.mjs.map (202 B)
  └─ dist/guards/is-empty-string.mjs (243 B)
  └─ dist/guards/is-empty-string.d.mts (324 B)
  └─ dist/guards/is-empty-value.mjs.map (223 B)
  └─ dist/guards/is-empty-value.mjs (296 B)
  └─ dist/guards/is-empty-value.d.mts (404 B)
  └─ dist/guards/is-jwt-type.mjs.map (208 B)
  └─ dist/guards/is-jwt-type.mjs (249 B)
  └─ dist/guards/is-jwt-type.d.mts (357 B)
  └─ dist/guards/is-nil.mjs.map (171 B)
  └─ dist/guards/is-nil.mjs (179 B)
  └─ dist/guards/is-nil.d.mts (336 B)
  └─ dist/guards/is-node-env.mjs.map (223 B)
  └─ dist/guards/is-node-env.mjs (272 B)
  └─ dist/guards/is-node-env.d.mts (386 B)
  └─ dist/guards/is-number-string.mjs.map (193 B)
  └─ dist/guards/is-number-string.mjs (247 B)
  └─ dist/guards/is-number-string.d.mts (355 B)
  └─ dist/guards/is-unix-timestamp.mjs.map (214 B)
  └─ dist/guards/is-unix-timestamp.mjs (268 B)
  └─ dist/guards/is-unix-timestamp.d.mts (410 B)
  └─ dist/interfaces/index.mjs.map (69 B)
  └─ dist/interfaces/index.mjs (35 B)
  └─ dist/interfaces/index.d.mts (125 B)
  └─ dist/interfaces/map-like.mjs.map (69 B)
  └─ dist/interfaces/map-like.mjs (38 B)
  └─ dist/interfaces/map-like.d.mts (256 B)
  └─ dist/types/any.mjs.map (69 B)
  └─ dist/types/any.mjs (33 B)
  └─ dist/types/any.d.mts (156 B)
  └─ dist/types/booleanish.mjs.map (69 B)
  └─ dist/types/booleanish.mjs (40 B)
  └─ dist/types/booleanish.d.mts (236 B)
  └─ dist/types/built-in.mjs.map (69 B)
  └─ dist/types/built-in.mjs (38 B)
  └─ dist/types/built-in.d.mts (243 B)
  └─ dist/types/class.mjs.map (69 B)
  └─ dist/types/class.mjs (35 B)
  └─ dist/types/class.d.mts (444 B)
  └─ dist/types/comparison-operator.mjs.map (69 B)
  └─ dist/types/comparison-operator.mjs (49 B)
  └─ dist/types/comparison-operator.d.mts (264 B)
  └─ dist/types/constructor.mjs.map (69 B)
  └─ dist/types/constructor.mjs (41 B)
  └─ dist/types/constructor.d.mts (411 B)
  └─ dist/types/continuous-value.mjs.map (69 B)
  └─ dist/types/continuous-value.mjs (46 B)
  └─ dist/types/continuous-value.d.mts (275 B)
  └─ dist/types/empty-string.mjs.map (69 B)
  └─ dist/types/empty-string.mjs (42 B)
  └─ dist/types/empty-string.d.mts (193 B)
  └─ dist/types/empty-value.mjs.map (69 B)
  └─ dist/types/empty-value.mjs (41 B)
  └─ dist/types/empty-value.d.mts (304 B)
  └─ dist/types/fixme.mjs.map (69 B)
  └─ dist/types/fixme.mjs (35 B)
  └─ dist/types/fixme.d.mts (202 B)
  └─ dist/types/index-signature.mjs.map (69 B)
  └─ dist/types/index-signature.mjs (45 B)
  └─ dist/types/index-signature.d.mts (300 B)
  └─ dist/types/index.mjs.map (69 B)
  └─ dist/types/index.mjs (35 B)
  └─ dist/types/index.d.mts (2.84 kB)
  └─ dist/types/is-tuple.mjs.map (69 B)
  └─ dist/types/is-tuple.mjs (38 B)
  └─ dist/types/is-tuple.d.mts (507 B)
  └─ dist/types/join.mjs.map (69 B)
  └─ dist/types/join.mjs (34 B)
  └─ dist/types/join.d.mts (498 B)
  └─ dist/types/json-array.mjs.map (69 B)
  └─ dist/types/json-array.mjs (40 B)
  └─ dist/types/json-array.d.mts (308 B)
  └─ dist/types/json-object.mjs.map (69 B)
  └─ dist/types/json-object.mjs (41 B)
  └─ dist/types/json-object.d.mts (751 B)
  └─ dist/types/json-primitive.mjs.map (69 B)
  └─ dist/types/json-primitive.mjs (44 B)
  └─ dist/types/json-primitive.d.mts (362 B)
  └─ dist/types/json-value.mjs.map (69 B)
  └─ dist/types/json-value.mjs (40 B)
  └─ dist/types/json-value.d.mts (397 B)
  └─ dist/types/jsonifiable-array.mjs.map (69 B)
  └─ dist/types/jsonifiable-array.mjs (47 B)
  └─ dist/types/jsonifiable-array.d.mts (363 B)
  └─ dist/types/jsonifiable-object.mjs.map (69 B)
  └─ dist/types/jsonifiable-object.mjs (48 B)
  └─ dist/types/jsonifiable-object.d.mts (415 B)
  └─ dist/types/jsonifiable.mjs.map (69 B)
  └─ dist/types/jsonifiable.mjs (41 B)
  └─ dist/types/jsonifiable.d.mts (510 B)
  └─ dist/types/keys-optional.mjs.map (69 B)
  └─ dist/types/keys-optional.mjs (43 B)
  └─ dist/types/keys-optional.d.mts (390 B)
  └─ dist/types/keys-required.mjs.map (69 B)
  └─ dist/types/keys-required.mjs (43 B)
  └─ dist/types/keys-required.d.mts (390 B)
  └─ dist/types/literal-union.mjs.map (69 B)
  └─ dist/types/literal-union.mjs (43 B)
  └─ dist/types/literal-union.d.mts (1.3 kB)
  └─ dist/types/nil.mjs.map (69 B)
  └─ dist/types/nil.mjs (33 B)
  └─ dist/types/nil.d.mts (189 B)
  └─ dist/types/nilable.mjs.map (69 B)
  └─ dist/types/nilable.mjs (37 B)
  └─ dist/types/nilable.d.mts (257 B)
  └─ dist/types/nullable.mjs.map (69 B)
  └─ dist/types/nullable.mjs (38 B)
  └─ dist/types/nullable.d.mts (248 B)
  └─ dist/types/number-like.mjs.map (69 B)
  └─ dist/types/number-like.mjs (41 B)
  └─ dist/types/number-like.d.mts (255 B)
  └─ dist/types/numeric.mjs.map (69 B)
  └─ dist/types/numeric.mjs (37 B)
  └─ dist/types/numeric.d.mts (188 B)
  └─ dist/types/object-empty.mjs.map (69 B)
  └─ dist/types/object-empty.mjs (42 B)
  └─ dist/types/object-empty.d.mts (213 B)
  └─ dist/types/object-plain.mjs.map (69 B)
  └─ dist/types/object-plain.mjs (42 B)
  └─ dist/types/object-plain.d.mts (296 B)
  └─ dist/types/object-unknown.mjs.map (69 B)
  └─ dist/types/object-unknown.mjs (44 B)
  └─ dist/types/object-unknown.d.mts (289 B)
  └─ dist/types/one-or-many.mjs.map (69 B)
  └─ dist/types/one-or-many.mjs (41 B)
  └─ dist/types/one-or-many.d.mts (245 B)
  └─ dist/types/opaque.mjs.map (69 B)
  └─ dist/types/opaque.mjs (36 B)
  └─ dist/types/opaque.d.mts (584 B)
  └─ dist/types/or-lowercase.mjs.map (69 B)
  └─ dist/types/or-lowercase.mjs (42 B)
  └─ dist/types/or-lowercase.d.mts (364 B)
  └─ dist/types/or-uppercase.mjs.map (69 B)
  └─ dist/types/or-uppercase.mjs (42 B)
  └─ dist/types/or-uppercase.d.mts (364 B)
  └─ dist/types/overwrite.mjs.map (69 B)
  └─ dist/types/overwrite.mjs (39 B)
  └─ dist/types/overwrite.d.mts (453 B)
  └─ dist/types/path-n.mjs.map (69 B)
  └─ dist/types/path-n.mjs (36 B)
  └─ dist/types/path-n.d.mts (683 B)
  └─ dist/types/path-nt.mjs.map (69 B)
  └─ dist/types/path-nt.mjs (37 B)
  └─ dist/types/path-nt.d.mts (468 B)
  └─ dist/types/path-value.mjs.map (69 B)
  └─ dist/types/path-value.mjs (40 B)
  └─ dist/types/path-value.d.mts (686 B)
  └─ dist/types/path.mjs.map (69 B)
  └─ dist/types/path.mjs (34 B)
  └─ dist/types/path.d.mts (532 B)
  └─ dist/types/predicate.mjs.map (69 B)
  └─ dist/types/predicate.mjs (39 B)
  └─ dist/types/predicate.d.mts (578 B)
  └─ dist/types/primitive.mjs.map (69 B)
  └─ dist/types/primitive.mjs (39 B)
  └─ dist/types/primitive.d.mts (351 B)
  └─ dist/types/promisable.mjs.map (69 B)
  └─ dist/types/promisable.mjs (40 B)
  └─ dist/types/promisable.d.mts (321 B)
  └─ dist/types/semantic-version.mjs.map (69 B)
  └─ dist/types/semantic-version.mjs (46 B)
  └─ dist/types/semantic-version.d.mts (465 B)
  └─ dist/types/simplify.mjs.map (69 B)
  └─ dist/types/simplify.mjs (38 B)
  └─ dist/types/simplify.d.mts (382 B)
  └─ dist/types/split.mjs.map (69 B)
  └─ dist/types/split.mjs (35 B)
  └─ dist/types/split.d.mts (423 B)
  └─ dist/types/string-like.mjs.map (69 B)
  └─ dist/types/string-like.mjs (41 B)
  └─ dist/types/string-like.d.mts (221 B)
  └─ dist/types/timestamp-unix.mjs.map (69 B)
  └─ dist/types/timestamp-unix.mjs (44 B)
  └─ dist/types/timestamp-unix.d.mts (271 B)
  dist (total size: 117 kB)                                                                         17:13:15
  └─ dist/index.cjs.map (178 B)
  └─ dist/index.cjs (1.15 kB)
  └─ dist/index.d.cts (161 B)
  └─ dist/enums/app-env.cjs.map (316 B)
  └─ dist/enums/app-env.cjs (1.22 kB)
  └─ dist/enums/app-env.d.cts (283 B)
  └─ dist/enums/bson-type-alias.cjs.map (354 B)
  └─ dist/enums/bson-type-alias.cjs (1.38 kB)
  └─ dist/enums/bson-type-alias.d.cts (432 B)
  └─ dist/enums/bson-type-code.cjs.map (387 B)
  └─ dist/enums/bson-type-code.cjs (1.48 kB)
  └─ dist/enums/bson-type-code.d.cts (390 B)
  └─ dist/enums/compare-result.cjs.map (309 B)
  └─ dist/enums/compare-result.cjs (1.34 kB)
  └─ dist/enums/compare-result.d.cts (445 B)
  └─ dist/enums/http-status.cjs.map (1.99 kB)
  └─ dist/enums/http-status.cjs (5.55 kB)
  └─ dist/enums/http-status.d.cts (1.89 kB)
  └─ dist/enums/index.cjs.map (299 B)
  └─ dist/enums/index.cjs (2.2 kB)
  └─ dist/enums/index.d.cts (554 B)
  └─ dist/enums/jwt-type.cjs.map (277 B)
  └─ dist/enums/jwt-type.cjs (1.2 kB)
  └─ dist/enums/jwt-type.d.cts (291 B)
  └─ dist/enums/node-env.cjs.map (276 B)
  └─ dist/enums/node-env.cjs (1.18 kB)
  └─ dist/enums/node-env.d.cts (244 B)
  └─ dist/enums/project-rule.cjs.map (276 B)
  └─ dist/enums/project-rule.cjs (1.23 kB)
  └─ dist/enums/project-rule.d.cts (253 B)
  └─ dist/enums/sort-order.cjs.map (272 B)
  └─ dist/enums/sort-order.cjs (1.22 kB)
  └─ dist/enums/sort-order.d.cts (333 B)
  └─ dist/guards/index.cjs.map (282 B)
  └─ dist/guards/index.cjs (2.15 kB)
  └─ dist/guards/index.d.cts (530 B)
  └─ dist/guards/is-app-env.cjs.map (265 B)
  └─ dist/guards/is-app-env.cjs (1.48 kB)
  └─ dist/guards/is-app-env.d.cts (357 B)
  └─ dist/guards/is-booleanish.cjs.map (235 B)
  └─ dist/guards/is-booleanish.cjs (1.15 kB)
  └─ dist/guards/is-booleanish.d.cts (397 B)
  └─ dist/guards/is-empty-string.cjs.map (244 B)
  └─ dist/guards/is-empty-string.cjs (1.15 kB)
  └─ dist/guards/is-empty-string.d.cts (324 B)
  └─ dist/guards/is-empty-value.cjs.map (300 B)
  └─ dist/guards/is-empty-value.cjs (1.59 kB)
  └─ dist/guards/is-empty-value.d.cts (404 B)
  └─ dist/guards/is-jwt-type.cjs.map (269 B)
  └─ dist/guards/is-jwt-type.cjs (1.49 kB)
  └─ dist/guards/is-jwt-type.d.cts (357 B)
  └─ dist/guards/is-nil.cjs.map (213 B)
  └─ dist/guards/is-nil.cjs (1.06 kB)
  └─ dist/guards/is-nil.d.cts (336 B)
  └─ dist/guards/is-node-env.cjs.map (284 B)
  └─ dist/guards/is-node-env.cjs (1.51 kB)
  └─ dist/guards/is-node-env.d.cts (386 B)
  └─ dist/guards/is-number-string.cjs.map (235 B)
  └─ dist/guards/is-number-string.cjs (1.16 kB)
  └─ dist/guards/is-number-string.d.cts (355 B)
  └─ dist/guards/is-unix-timestamp.cjs.map (256 B)
  └─ dist/guards/is-unix-timestamp.cjs (1.18 kB)
  └─ dist/guards/is-unix-timestamp.d.cts (410 B)
  └─ dist/types/any.cjs.map (116 B)
  └─ dist/types/any.cjs (756 B)
  └─ dist/types/any.d.cts (156 B)
  └─ dist/types/booleanish.cjs.map (123 B)
  └─ dist/types/booleanish.cjs (777 B)
  └─ dist/types/booleanish.d.cts (236 B)
  └─ dist/types/built-in.cjs.map (121 B)
  └─ dist/types/built-in.cjs (771 B)
  └─ dist/types/built-in.d.cts (243 B)
  └─ dist/types/class.cjs.map (118 B)
  └─ dist/types/class.cjs (762 B)
  └─ dist/types/class.d.cts (444 B)
  └─ dist/types/comparison-operator.cjs.map (132 B)
  └─ dist/types/comparison-operator.cjs (804 B)
  └─ dist/types/comparison-operator.d.cts (264 B)
  └─ dist/types/constructor.cjs.map (124 B)
  └─ dist/types/constructor.cjs (780 B)
  └─ dist/types/constructor.d.cts (411 B)
  └─ dist/types/continuous-value.cjs.map (129 B)
  └─ dist/types/continuous-value.cjs (795 B)
  └─ dist/types/continuous-value.d.cts (275 B)
  └─ dist/types/empty-string.cjs.map (125 B)
  └─ dist/types/empty-string.cjs (783 B)
  └─ dist/types/empty-string.d.cts (193 B)
  └─ dist/types/empty-value.cjs.map (124 B)
  └─ dist/types/empty-value.cjs (780 B)
  └─ dist/types/empty-value.d.cts (304 B)
  └─ dist/types/fixme.cjs.map (118 B)
  └─ dist/types/fixme.cjs (762 B)
  └─ dist/types/fixme.d.cts (202 B)
  └─ dist/types/index-signature.cjs.map (128 B)
  └─ dist/types/index-signature.cjs (792 B)
  └─ dist/types/index-signature.d.cts (300 B)
  └─ dist/types/index.cjs.map (118 B)
  └─ dist/types/index.cjs (762 B)
  └─ dist/types/index.d.cts (2.84 kB)
  └─ dist/types/is-tuple.cjs.map (121 B)
  └─ dist/types/is-tuple.cjs (771 B)
  └─ dist/types/is-tuple.d.cts (507 B)
  └─ dist/types/join.cjs.map (117 B)
  └─ dist/types/join.cjs (759 B)
  └─ dist/types/join.d.cts (498 B)
  └─ dist/types/json-array.cjs.map (123 B)
  └─ dist/types/json-array.cjs (777 B)
  └─ dist/types/json-array.d.cts (308 B)
  └─ dist/types/json-object.cjs.map (124 B)
  └─ dist/types/json-object.cjs (780 B)
  └─ dist/types/json-object.d.cts (751 B)
  └─ dist/types/json-primitive.cjs.map (127 B)
  └─ dist/types/json-primitive.cjs (789 B)
  └─ dist/types/json-primitive.d.cts (362 B)
  └─ dist/types/json-value.cjs.map (123 B)
  └─ dist/types/json-value.cjs (777 B)
  └─ dist/types/json-value.d.cts (397 B)
  └─ dist/types/jsonifiable-array.cjs.map (130 B)
  └─ dist/types/jsonifiable-array.cjs (798 B)
  └─ dist/types/jsonifiable-array.d.cts (363 B)
  └─ dist/types/jsonifiable-object.cjs.map (131 B)
  └─ dist/types/jsonifiable-object.cjs (801 B)
  └─ dist/types/jsonifiable-object.d.cts (415 B)
  └─ dist/types/jsonifiable.cjs.map (124 B)
  └─ dist/types/jsonifiable.cjs (780 B)
  └─ dist/types/jsonifiable.d.cts (510 B)
  └─ dist/types/keys-optional.cjs.map (126 B)
  └─ dist/types/keys-optional.cjs (786 B)
  └─ dist/types/keys-optional.d.cts (390 B)
  └─ dist/types/keys-required.cjs.map (126 B)
  └─ dist/types/keys-required.cjs (786 B)
  └─ dist/types/keys-required.d.cts (390 B)
  └─ dist/types/literal-union.cjs.map (126 B)
  └─ dist/types/literal-union.cjs (786 B)
  └─ dist/types/literal-union.d.cts (1.3 kB)
  └─ dist/types/nil.cjs.map (116 B)
  └─ dist/types/nil.cjs (756 B)
  └─ dist/types/nil.d.cts (189 B)
  └─ dist/types/nilable.cjs.map (120 B)
  └─ dist/types/nilable.cjs (768 B)
  └─ dist/types/nilable.d.cts (257 B)
  └─ dist/types/nullable.cjs.map (121 B)
  └─ dist/types/nullable.cjs (771 B)
  └─ dist/types/nullable.d.cts (248 B)
  └─ dist/types/number-like.cjs.map (124 B)
  └─ dist/types/number-like.cjs (780 B)
  └─ dist/types/number-like.d.cts (255 B)
  └─ dist/types/numeric.cjs.map (120 B)
  └─ dist/types/numeric.cjs (768 B)
  └─ dist/types/numeric.d.cts (188 B)
  └─ dist/types/object-empty.cjs.map (125 B)
  └─ dist/types/object-empty.cjs (783 B)
  └─ dist/types/object-empty.d.cts (213 B)
  └─ dist/types/object-plain.cjs.map (125 B)
  └─ dist/types/object-plain.cjs (783 B)
  └─ dist/types/object-plain.d.cts (296 B)
  └─ dist/types/object-unknown.cjs.map (127 B)
  └─ dist/types/object-unknown.cjs (789 B)
  └─ dist/types/object-unknown.d.cts (289 B)
  └─ dist/types/one-or-many.cjs.map (124 B)
  └─ dist/types/one-or-many.cjs (780 B)
  └─ dist/types/one-or-many.d.cts (245 B)
  └─ dist/types/opaque.cjs.map (119 B)
  └─ dist/types/opaque.cjs (765 B)
  └─ dist/types/opaque.d.cts (584 B)
  └─ dist/types/or-lowercase.cjs.map (125 B)
  └─ dist/types/or-lowercase.cjs (783 B)
  └─ dist/types/or-lowercase.d.cts (364 B)
  └─ dist/types/or-uppercase.cjs.map (125 B)
  └─ dist/types/or-uppercase.cjs (783 B)
  └─ dist/types/or-uppercase.d.cts (364 B)
  └─ dist/types/overwrite.cjs.map (122 B)
  └─ dist/types/overwrite.cjs (774 B)
  └─ dist/types/overwrite.d.cts (453 B)
  └─ dist/types/path-n.cjs.map (119 B)
  └─ dist/types/path-n.cjs (765 B)
  └─ dist/types/path-n.d.cts (683 B)
  └─ dist/types/path-nt.cjs.map (120 B)
  └─ dist/types/path-nt.cjs (768 B)
  └─ dist/types/path-nt.d.cts (468 B)
  └─ dist/types/path-value.cjs.map (123 B)
  └─ dist/types/path-value.cjs (777 B)
  └─ dist/types/path-value.d.cts (686 B)
  └─ dist/types/path.cjs.map (117 B)
  └─ dist/types/path.cjs (759 B)
  └─ dist/types/path.d.cts (532 B)
  └─ dist/types/predicate.cjs.map (122 B)
  └─ dist/types/predicate.cjs (774 B)
  └─ dist/types/predicate.d.cts (578 B)
  └─ dist/types/primitive.cjs.map (122 B)
  └─ dist/types/primitive.cjs (774 B)
  └─ dist/types/primitive.d.cts (351 B)
  └─ dist/types/promisable.cjs.map (123 B)
  └─ dist/types/promisable.cjs (777 B)
  └─ dist/types/promisable.d.cts (321 B)
  └─ dist/types/semantic-version.cjs.map (129 B)
  └─ dist/types/semantic-version.cjs (795 B)
  └─ dist/types/semantic-version.d.cts (465 B)
  └─ dist/types/simplify.cjs.map (121 B)
  └─ dist/types/simplify.cjs (771 B)
  └─ dist/types/simplify.d.cts (382 B)
  └─ dist/types/split.cjs.map (118 B)
  └─ dist/types/split.cjs (762 B)
  └─ dist/types/split.d.cts (423 B)
  └─ dist/types/string-like.cjs.map (124 B)
  └─ dist/types/string-like.cjs (780 B)
  └─ dist/types/string-like.d.cts (221 B)
  └─ dist/types/timestamp-unix.cjs.map (127 B)
  └─ dist/types/timestamp-unix.cjs (789 B)
  └─ dist/types/timestamp-unix.d.cts (271 B)
  └─ dist/interfaces/index.cjs.map (123 B)
  └─ dist/interfaces/index.cjs (772 B)
  └─ dist/interfaces/index.d.cts (125 B)
  └─ dist/interfaces/map-like.cjs.map (126 B)
  └─ dist/interfaces/map-like.cjs (771 B)
  └─ dist/interfaces/map-like.d.cts (256 B)
Σ Total build size: 172 kB                                                                          17:13:15
```

## Additional context

<!-- Add any other information (docs, files, issue references, etc) about the pull request here. -->

N/A

## Linked issues

<!-- closes #[issue number], fixes #[issue number] -->

N/A

## Submission checklist

- [x] self-review performed
- [x] tests added and/or updated
- [x] documentation added or updated
- [x] new, **tolerable** vulnerabilities and/or warnings documented, if any
- [x] [pr naming conventions][1]

[1]: https://github.com/flex-development/tutils/blob/main/CONTRIBUTING.md#pull-request-titles
