### PR TITLE
release: tutils@6.0.0-alpha.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+## [tutils@6.0.0-alpha.9](https://github.com/flex-development/tutils/compare/tutils@6.0.0-alpha.8...tutils@6.0.0-alpha.9) (2023-01-08)
+
+
+### :package: Build
+
+* **deps-dev:** Bump esbuild from 0.16.15 to 0.16.16 ([#101](https://github.com/flex-development/tutils/issues/101)) ([94f94e6](https://github.com/flex-development/tutils/commit/94f94e67be999432a6ed8135bb4b0da5e1fbc1d0))
+* **deps-dev:** Bump typescript from 5.0.0-dev.20230107 to 5.0.0-dev.20230108 ([#102](https://github.com/flex-development/tutils/issues/102)) ([c872ad1](https://github.com/flex-development/tutils/commit/c872ad124992f6efbeef0a9f8399bb7c2a68117e))
+
+
+### :robot: Continuous Integration
+
+* **deps:** Bump actions/setup-node from 3.5.1 to 3.6.0 ([#103](https://github.com/flex-development/tutils/issues/103)) ([069d364](https://github.com/flex-development/tutils/commit/069d3648b6ba1da763de8c8f40c783216b3ba5f3))
+
+
+### :bug: Fixes
+
+* **ts:** missing types in build output ([e62e94b](https://github.com/flex-development/tutils/commit/e62e94b3980a55869516652176cc3c79c5d65957))
+
+
+### :house_with_garden: Housekeeping
+
+* **ts:** fix custom typings ([2832024](https://github.com/flex-development/tutils/commit/283202464640d16e9a01d3d6ea818b7cb8f4373e))
+
+
+### :zap: Refactors
+
+* **ts:** catch build output errors early ([9f373ac](https://github.com/flex-development/tutils/commit/9f373ac80b0b6a7c14a3ed90ad2ba83059cb4f3d))
+
 ## [tutils@6.0.0-alpha.8](https://github.com/flex-development/tutils/compare/tutils@6.0.0-alpha.7...tutils@6.0.0-alpha.8) (2023-01-07)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flex-development/tutils",
   "description": "TypeScript utilities",
-  "version": "6.0.0-alpha.8",
+  "version": "6.0.0-alpha.9",
   "keywords": [
     "enums",
     "interfaces",


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

- bumped version to `6.0.0-alpha.9`
- added `CHANGELOG` entry for `tutils@6.0.0-alpha.9`

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

### `yarn test:cov`

```zsh
 RUN  v0.26.3
      Coverage enabled with c8

 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [[]]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [{}]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [13]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [true]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given [false]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return false given ["string"]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return true given [null]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return false given ["ci"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return false given ["cd"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return false given ["PROD"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["ci"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["development"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["staging"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["production"]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given [[]]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given [{}]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given [13]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given [false]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return false given ["hello world"]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return true given [""]
 ✓ src/guards/__tests__/is-empty-string.spec.ts > unit:guards/isEmptyString > should return true given ["   "]
 ✓ src/guards/__tests__/is-unix-timestamp.spec.ts > unit:guards/isUnixTimestamp > should return false given [null]
 ✓ src/guards/__tests__/is-unix-timestamp.spec.ts > unit:guards/isUnixTimestamp > should return true given [1673235353491]
 ✓ src/guards/__tests__/is-jwt-type.spec.ts > unit:guards/isJwtType > should return false given ["EMAIL"]
 ✓ src/guards/__tests__/is-jwt-type.spec.ts > unit:guards/isJwtType > should return true given ["ACCESS"]
 ✓ src/guards/__tests__/is-jwt-type.spec.ts > unit:guards/isJwtType > should return true given ["REFRESH"]
 ✓ src/guards/__tests__/is-jwt-type.spec.ts > unit:guards/isJwtType > should return true given ["VERIFICATION"]
 ✓ src/guards/__tests__/is-app-env.spec.ts > unit:guards/isAppEnv > should return true given ["test"]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return false given ["ci"]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return false given ["DEV"]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return true given ["development"]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return true given ["production"]
 ✓ src/guards/__tests__/is-node-env.spec.ts > unit:guards/isNodeEnv > should return true given ["test"]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return false given [[]]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return false given [{}]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return false given [true]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return false given [false]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return true given [13]
 ✓ src/guards/__tests__/is-number-string.spec.ts > unit:guards/isNumberString > should return true given ["hello world"]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return false given [[]]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return false given [{}]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return false given [13]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return true given [true]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return true given ["true"]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return true given [false]
 ✓ src/guards/__tests__/is-booleanish.spec.ts > unit:guards/isBooleanish > should return true given ["false"]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return true given [null]
 ✓ src/guards/__tests__/is-nil.spec.ts > unit:guards/isNIL > should return true given [undefined]
 ✓ src/guards/__tests__/is-empty-value.functional.spec.ts > functional:guards/isEmptyValue > should call isEmptyString 1 time and isNIL 0 times given [""]
 ✓ src/guards/__tests__/is-empty-value.functional.spec.ts > functional:guards/isEmptyValue > should call isEmptyString 1 time and isNIL 0 times given ["   "]
 ✓ src/guards/__tests__/is-empty-value.functional.spec.ts > functional:guards/isEmptyValue > should call isEmptyString 1 time and isNIL 1 time given [null]
 ✓ src/guards/__tests__/is-empty-value.functional.spec.ts > functional:guards/isEmptyValue > should call isEmptyString 1 time and isNIL 1 time given [undefined]

 Test Files  9 passed (9)
      Tests  50 passed (50)
   Start at  22:35:50
   Duration  3.70s (transform 997ms, setup 6.05s, collect 594ms, tests 565ms)

 % Coverage report from c8
-----------------------|---------|----------|---------|---------|-------------------
File                   | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------|---------|----------|---------|---------|-------------------
All files              |   55.44 |    76.92 |      60 |   55.44 |                   
 enums                 |    23.8 |    33.33 |       0 |    23.8 |                   
  app-env.ts           |     100 |      100 |     100 |     100 |                   
  bson-type-alias.ts   |       0 |        0 |       0 |       0 | 1-22              
  bson-type-code.ts    |       0 |        0 |       0 |       0 | 1-22              
  compare-result.ts    |       0 |        0 |       0 |       0 | 1-21              
  http-status.ts       |       0 |        0 |       0 |       0 | 1-77              
  jwt-type.ts          |     100 |      100 |     100 |     100 |                   
  node-env.ts          |     100 |      100 |     100 |     100 |                   
  project-rule.ts      |       0 |        0 |       0 |       0 | 1-16              
  sort-order.ts        |       0 |        0 |       0 |       0 | 1-18              
 guards                |     100 |      100 |     100 |     100 |                   
  is-app-env.ts        |     100 |      100 |     100 |     100 |                   
  is-booleanish.ts     |     100 |      100 |     100 |     100 |                   
  is-empty-string.ts   |     100 |      100 |     100 |     100 |                   
  is-empty-value.ts    |     100 |      100 |     100 |     100 |                   
  is-jwt-type.ts       |     100 |      100 |     100 |     100 |                   
  is-nil.ts            |     100 |      100 |     100 |     100 |                   
  is-node-env.ts       |     100 |      100 |     100 |     100 |                   
  is-number-string.ts  |     100 |      100 |     100 |     100 |                   
  is-unix-timestamp.ts |     100 |      100 |     100 |     100 |                   
-----------------------|---------|----------|---------|---------|-------------------
```

## Additional context

<!-- Add any other information (docs, files, issue references, etc) about the pull request here. -->

N/A

## Linked issues

<!-- closes #[issue number], fixes #[issue number] -->

N/A

## Submission checklist

- [x] self-review performed
- [x] tests added and/or updated
- [x] documentation added or updated
- [x] new, **tolerable** vulnerabilities and/or warnings documented, if any
- [x] [pr naming conventions][1]

[1]: https://github.com/flex-development/tutils/blob/main/CONTRIBUTING.md#pull-request-titles
